### PR TITLE
docs: add AI development scaffold and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+make build       # Build the provider
+make install     # Build and install to GOPATH
+make test        # Run unit tests (with coverage, 120s timeout, 10 parallel)
+make testacc     # Run acceptance tests (requires TF_ACC=1, hits real API)
+make lint        # Run golangci-lint via tools/go.mod
+make fmt         # Format with gofumpt
+make generate    # Regenerate docs (runs terraform fmt on examples/, then tfplugindocs)
+make update      # Pull git submodules
+```
+
+Run a single test:
+```bash
+go test -v -run TestAccBlockStorage ./internal/acctest/
+go test -v -run TestFoo ./internal/provider/
+```
+
+Acceptance tests require a live SECA cluster. The `internal/acctest/provider_test.go` hardcodes endpoint URLs for a local cluster at `172.18.0.2:30081`.
+
+## Architecture
+
+This is a [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework) provider for the EU Sovereign Cloud (SECA) platform, registered at `registry.terraform.io/eu-sovereign-cloud/seca`.
+
+### Key layers
+
+- **`main.go`** — entrypoint; supports `--debug` flag for Delve
+- **`internal/provider/`** — all provider logic (single package)
+- **`internal/acctest/`** — acceptance tests (separate package; uses `testAccProtoV6ProviderFactories`)
+- **`tools/`** — separate Go module for dev tooling (golangci-lint, tfplugindocs, gofumpt)
+- **`spec/`** — git submodule pointing to `github.com/eu-sovereign-cloud/spec`
+
+### Client initialization (`clients.go`)
+
+The provider initializes two SDK clients from `github.com/eu-sovereign-cloud/go-sdk/secapi`:
+- `GlobalClient` — talks to global endpoints (region registry, authorization)
+- `RegionalClient` — derived from `GlobalClient.NewRegionalClient()`; used by all resources/data sources
+
+Both are passed to resources and data sources via `resp.DataSourceData` / `resp.ResourceData` as the `clients` struct.
+
+### Resource/data source pattern
+
+Each resource and data source follows this structure:
+1. A struct implementing the framework interface (e.g., `BlockStorageResource`) holds `*secapi.RegionalClient`, `tenant`, `region`, and retry config.
+2. `Configure()` casts `req.ProviderData.(clients)` to extract the shared clients.
+3. A `*Model` struct (e.g., `BlockStorageModel`) maps Terraform schema fields using `tfsdk` tags.
+4. Two private helpers convert between SDK types and model: `fooFromModel()` and `fooToModel()`.
+5. Mutating operations (Create/Update) poll for `ResourceStateActive` using `GetXxxUntilState()` with configurable retry delay/interval/max_attempts.
+
+### Type utilities (`types.go`)
+
+Shared helpers for converting between Terraform framework types and Go types: `numberToDuration`, `numberToInt`, `toStringMap`, `fromStringMap`, `fromTime`, `fromTimePtr`, `fromRefPtr`.
+
+### Provider configuration
+
+Required: `token`, `tenant`, `region`, `global_providers.region_v1`. Optional: `global_providers.authorization_v1`, `retry` block (delay/interval/max_attempts in seconds). Default retry: 30s delay, 10s interval, 5 attempts.
+
+### Linting rules
+
+The `depguard` linter enforces use of `terraform-plugin-testing` over the older `terraform-plugin-sdk/v2` test helpers. Do not import `terraform-plugin-sdk/v2` for testing.
+
+### Documentation generation
+
+Docs in `docs/` are auto-generated from resource/data source schema descriptions and `examples/` `.tf` files. Run `make generate` after schema changes; CI fails if generated docs diverge from committed files.
+
+## AI Development Scaffold
+
+The `ai/` directory contains comprehensive documentation for AI-assisted development. Read it before implementing, reviewing, or refactoring provider code:
+
+- `ai/README.md` — navigation and reading order
+- `ai/guardrails.md` — hard rules (read first before any code change)
+- `ai/implementation-checklist.md` — step-by-step checklist for new resources
+- `ai/review-checklist.md` — checklist for PR reviews
+- `ai/known-issues.md` — technical debt; do not accidentally work around these
+- `ai/prompts/` — ready-to-use prompts for common AI tasks

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,46 @@
+# AI Development Scaffold
+
+This directory is the authoritative reference for AI-assisted development in this repository. Every document is grounded in the actual implementation — nothing here is generic advice.
+
+## Purpose
+
+These documents onboard AI agents (and human contributors) to work safely, consistently, and correctly in this Terraform provider codebase. Read them before writing, reviewing, or refactoring code.
+
+## Document Map
+
+| Document | When to read |
+|---|---|
+| [requirements.md](requirements.md) | Supported versions, provider goals, compatibility rules |
+| [architecture.md](architecture.md) | Package layout, client model, provider lifecycle |
+| [provider-conventions.md](provider-conventions.md) | Naming, schema patterns, resource identity |
+| [terraform-framework.md](terraform-framework.md) | Framework-specific usage patterns for this provider |
+| [async-operations.md](async-operations.md) | How every write operation waits for `Active` state |
+| [coding-guidelines.md](coding-guidelines.md) | Go code standards enforced in this repo |
+| [testing-strategy.md](testing-strategy.md) | Unit vs acceptance tests, what to cover |
+| [guardrails.md](guardrails.md) | Hard rules — read this before any code change |
+| [review-checklist.md](review-checklist.md) | Checklist for reviewing PRs |
+| [implementation-checklist.md](implementation-checklist.md) | Checklist for implementing new resources/data sources |
+| [known-issues.md](known-issues.md) | Technical debt — do not accidentally work around these |
+| [roadmap.md](roadmap.md) | Planned resources and their priority |
+| [glossary.md](glossary.md) | Domain terminology and SDK type mapping |
+
+## Prompts
+
+Ready-to-use prompts for common AI tasks:
+
+| Prompt | Use for |
+|---|---|
+| [prompts/implementation.md](prompts/implementation.md) | Implementing a new resource or data source |
+| [prompts/feature.md](prompts/feature.md) | Adding a feature to an existing resource |
+| [prompts/review.md](prompts/review.md) | Code review of a PR or diff |
+| [prompts/bugfix.md](prompts/bugfix.md) | Investigating and fixing a bug |
+| [prompts/refactor.md](prompts/refactor.md) | Safe refactoring of existing code |
+
+## Reading Order for a New Contributor
+
+1. [requirements.md](requirements.md) — understand what this provider does
+2. [architecture.md](architecture.md) — understand the code structure
+3. [async-operations.md](async-operations.md) — understand the most critical pattern
+4. [provider-conventions.md](provider-conventions.md) — understand naming and schema rules
+5. [guardrails.md](guardrails.md) — understand what never to do
+6. [implementation-checklist.md](implementation-checklist.md) — before writing any new resource

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,131 @@
+# Architecture
+
+## Package Layout
+
+```
+terraform-provider-seca/
+├── main.go                     # Entry point; --debug flag for Delve
+├── internal/
+│   ├── provider/               # All provider logic (single flat package)
+│   │   ├── provider.go         # Provider struct, schema, Configure, resource/datasource lists
+│   │   ├── clients.go          # Client struct, initClients(), retry constants
+│   │   ├── types.go            # Shared type-conversion helpers
+│   │   ├── resource_*.go       # One file per resource
+│   │   ├── datasource_*.go     # One file per data source
+│   │   └── *_test.go           # Unit tests for mapping functions
+│   └── acctest/                # Acceptance tests (separate package)
+│       ├── provider_test.go    # Shared provider factory and config builder
+│       └── *_test.go           # One file per resource/data source
+├── tools/                      # Separate Go module for tooling
+│   ├── go.mod
+│   └── tools.go                # go:generate directives
+├── examples/                   # Terraform HCL examples (used by tfplugindocs)
+├── docs/                       # Auto-generated documentation
+└── spec/                       # Git submodule: eu-sovereign-cloud/spec
+```
+
+## Client Model
+
+The provider initializes two SDK clients during `Configure()` and passes them to every resource and data source via `resp.DataSourceData` / `resp.ResourceData`.
+
+```
+Provider.Configure()
+    └─ initClients()
+           ├─ secapi.NewGlobalClient(token, endpoints)   → GlobalClient
+           └─ globalClient.NewRegionalClient(ctx, region) → RegionalClient
+
+clients struct {
+    Tenant, Region string
+    RetryDelay, RetryInterval time.Duration
+    RetryMaxAttempts int
+    GlobalClient   *secapi.GlobalClient    ← used by seca_region only
+    RegionalClient *secapi.RegionalClient  ← used by all other resources/data sources
+}
+```
+
+`RegionalClient` is derived from `GlobalClient` using the region name. The GlobalClient discovers the regional endpoint from the `RegionV1` global endpoint. This design means the provider must be able to reach the global region endpoint at startup; regional endpoints are resolved dynamically.
+
+## Provider Lifecycle
+
+```
+1. Terraform reads HCL → calls Provider.Configure()
+2. Configure() decodes SecaProviderModel (token, tenant, region, retry, global_providers)
+3. initClients() is called:
+   a. NewGlobalClient(token, {RegionV1, AuthorizationV1}) → authenticates
+   b. globalClient.NewRegionalClient(ctx, region) → resolves regional endpoint
+4. clients{} struct is set on resp.DataSourceData AND resp.ResourceData
+5. Each resource/data source's Configure() casts ProviderData.(clients) to extract its client
+```
+
+## Resource Lifecycle
+
+Every resource follows this exact pattern:
+
+```
+Configure()  → casts ProviderData to clients{}, stores client + tenant + region + retry params
+Metadata()   → sets TypeName = providerTypeName + "_resource_name"
+Schema()     → declares all attributes (see provider-conventions.md)
+Create()     → reads Plan → calls CreateOrUpdateXxx() → polls GetXxxUntilState() → writes State
+Read()       → reads State → calls GetXxx() → writes State
+Update()     → reads Plan → calls CreateOrUpdateXxx() → polls GetXxxUntilState() → writes State
+Delete()     → reads State → calls DeleteXxx()
+```
+
+Delete does **not** poll for deletion completion (see [known-issues.md](known-issues.md)).
+
+## SDK Layering
+
+```
+Terraform Plugin Framework
+    ↓ (tfsdk model structs)
+internal/provider  (resource/datasource files)
+    ↓ (calls)
+go-sdk/secapi  (GlobalClient, RegionalClient)
+    ↓ (HTTP)
+go-sdk/pkg/spec/schema  (SDK types: *sdk.Workspace, *sdk.Image, etc.)
+    ↓
+SECA REST API
+```
+
+The mapping between Terraform models and SDK types is done exclusively by the private `xxxFromModel()` and `xxxToXxxModel()` helper functions at the bottom of each file.
+
+## Reference System
+
+The SECA API uses a `<kind>/<name>` format for resource references:
+
+- `regions/region-1`
+- `workspaces/workspace-1`
+- `block-storages/my-vol`
+- `images/my-image`
+- `storage-skus/RD500`
+
+These full references are stored as Terraform `id` (mapped from `Metadata.Ref`). When resources reference each other (e.g., `block_storage_id` on an image), they store the full reference string.
+
+## Scoping Model
+
+SECA resources have three scopes:
+
+| Scope | Reference type | Examples |
+|---|---|---|
+| Global | `sdk.GlobalResourceMetadata` | Region |
+| Tenant | `sdk.RegionalResourceMetadata` (Tenant field) | Workspace, Image, StorageSku |
+| Workspace | `sdk.RegionalWorkspaceResourceMetadata` (Tenant + Workspace fields) | BlockStorage |
+
+Resources at Tenant scope use `secapi.TenantReference{Tenant, Name}` for API calls.
+Resources at Workspace scope use `secapi.WorkspaceReference{Tenant, Workspace, Name}`.
+
+## Error Handling Flow
+
+```
+API call returns error
+    → resp.Diagnostics.AddError("Error <verb>ing <resource>", "..."+err.Error())
+    → return
+
+Diagnostics.Append() returns diagnostics from model mapping
+    → check resp.Diagnostics.HasError() immediately after
+    → return if true
+
+State.Set() errors are appended automatically via Diagnostics.Append()
+```
+
+There is no global error handler. Every error is surfaced as a diagnostic.

--- a/ai/async-operations.md
+++ b/ai/async-operations.md
@@ -1,0 +1,88 @@
+# Async Operations
+
+## Why Resources Are Async
+
+The SECA API is eventually consistent. `CreateOrUpdateXxx()` returns as soon as the API accepts the request, but the resource may still be provisioning. The provider must poll until the resource reaches `Active` state before writing state to Terraform. Without this, Terraform would read back an incomplete resource on the next plan.
+
+## The Polling Pattern
+
+Every `Create()` and `Update()` in this provider follows these exact steps:
+
+```go
+// Step 1: Submit the mutation
+result, err := resource.client.StorageV1.CreateOrUpdateXxx(ctx, sdkObject)
+if err != nil {
+    resp.Diagnostics.AddError("Error creating Xxx", "...\nError: "+err.Error())
+    return
+}
+
+// Step 2: Build the reference for polling
+ref := secapi.TenantReference{          // or WorkspaceReference for workspace-scoped
+    Tenant: secapi.TenantID(result.Metadata.Tenant),
+    Name:   result.Metadata.Name,
+}
+
+// Step 3: Configure polling
+config := secapi.ResourceObserverUntilValueConfig[sdk.ResourceState]{
+    ExpectedValues: []sdk.ResourceState{sdk.ResourceStateActive},
+    Delay:          resource.retryDelay,       // time before first poll
+    Interval:       resource.retryInterval,    // time between polls
+    MaxAttempts:    resource.retryMaxAttempts, // max number of polls
+}
+
+// Step 4: Poll until active (or fail)
+result, err = resource.client.StorageV1.GetXxxUntilState(ctx, ref, config)
+if err != nil {
+    resp.Diagnostics.AddError("Error creating Xxx", "...\nError: "+err.Error())
+    return
+}
+```
+
+**The result from Step 4 (not Step 1) must be used to populate Terraform state.** The state must reflect the fully provisioned resource, not the intermediate response from the create call.
+
+## Retry Configuration
+
+Retry parameters are configured at the provider level and passed to each resource via the `clients` struct:
+
+| Parameter | Default | Provider attribute |
+|---|---|---|
+| `RetryDelay` | `30s` | `retry.delay` (seconds) |
+| `RetryInterval` | `10s` | `retry.interval` (seconds) |
+| `RetryMaxAttempts` | `5` | `retry.max_attempts` |
+
+`Delay` is the initial wait before the first poll (allows the API time to begin provisioning). `Interval` is the wait between subsequent polls.
+
+These can be overridden per provider block:
+
+```hcl
+provider "seca" {
+  retry = {
+    delay        = 60
+    interval     = 15
+    max_attempts = 20
+  }
+}
+```
+
+## Reference Type Selection
+
+The polling reference type depends on the resource scope:
+
+| Resource scope | Reference type | Fields |
+|---|---|---|
+| Tenant | `secapi.TenantReference` | `Tenant`, `Name` |
+| Workspace | `secapi.WorkspaceReference` | `Tenant`, `Workspace`, `Name` |
+
+Always use the **result from the initial API call** to populate the reference (e.g., `result.Metadata.Tenant`), not the values from the Terraform model. This is because the API may assign or normalize field values.
+
+## Delete Operations
+
+`Delete()` does **not** poll. It calls `DeleteXxx()` and returns immediately. This is a known gap (see [known-issues.md](known-issues.md)). The API is expected to handle deletion asynchronously, and subsequent `Read()` calls will detect when the resource is gone.
+
+## What NOT to Do
+
+- Never write state from the Step 1 result. Always use the Step 4 (poll) result.
+- Never skip the polling step for Create or Update, even for "fast" resources.
+- Never use `time.Sleep` directly. Always use `GetXxxUntilState()`.
+- Never hard-code delay/interval values. Always use the resource struct's retry fields.
+- Never ignore the error from `GetXxxUntilState()`.

--- a/ai/coding-guidelines.md
+++ b/ai/coding-guidelines.md
@@ -1,0 +1,139 @@
+# Coding Guidelines
+
+## Formatting
+
+- Formatter: `gofumpt` (stricter than `gofmt`; run via `make fmt`)
+- Linter: `golangci-lint v2` (run via `make lint`)
+- CI will reject builds that do not pass both
+
+## Imports
+
+Import alias conventions observed in the codebase:
+
+```go
+import (
+    // stdlib first (no alias)
+    "context"
+    "fmt"
+    "time"
+
+    // framework packages (use tfschema alias where needed to avoid collision)
+    "github.com/hashicorp/terraform-plugin-framework/datasource"
+    tfschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+
+    // SDK packages (always alias spec/schema as sdk)
+    sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+    "github.com/eu-sovereign-cloud/go-sdk/secapi"
+)
+```
+
+The `sdk` alias is always used for `go-sdk/pkg/spec/schema`. The `tfschema` alias is used for both `datasource/schema` and `resource/schema` packages to prevent name collision with the `schema` sub-package within the same file.
+
+## Package Structure
+
+- All provider code lives in `package provider` (`internal/provider/`)
+- All acceptance tests live in `package acctest` (`internal/acctest/`)
+- Unit tests in `internal/provider/` use `package provider` (white-box)
+- Never create sub-packages inside `internal/provider/` — all code stays flat
+
+## Naming
+
+- Resource types: `XxxResource` (PascalCase, singular noun)
+- Model types: `XxxModel` (for resources), `XxxDataSourceModel` (for data sources)
+- Private helpers: `xxxFromModel`, `xxxToResourceModel`, `xxxToDataSourceModel` (camelCase)
+- Constructor functions: `newXxxResource()`, `newXxxDataSource()`
+- Avoid abbreviations unless they are domain terms (e.g., `sku`, `nic`)
+
+## Error Handling
+
+- **Always** check errors from SDK calls immediately
+- **Always** call `resp.Diagnostics.AddError()` before returning on error
+- **Always** check `resp.Diagnostics.HasError()` after `Diagnostics.Append()`
+- Do **not** wrap errors redundantly — the SDK error message is already included in the detail string
+- Do **not** use `panic()` — use diagnostics
+
+```go
+// Correct
+result, err := r.client.StorageV1.CreateOrUpdateBlockStorage(ctx, block)
+if err != nil {
+    resp.Diagnostics.AddError(
+        "Error creating block storage",
+        "An error was encountered when creating the block storage.\nError: "+err.Error(),
+    )
+    return
+}
+
+// Wrong — ignoring err
+result, _ := r.client.StorageV1.CreateOrUpdateBlockStorage(ctx, block)
+```
+
+## Context
+
+- Always pass `ctx` as the first argument to SDK calls
+- Never create a new `context.Background()` inside a resource method — use the one provided
+- The framework manages cancellation; respect it by passing ctx everywhere
+
+## Mapping Functions
+
+Each resource/data source file defines private mapping functions at the bottom:
+
+```go
+// SDK type → resource Terraform model
+func xxxToResourceModel(ctx context.Context, obj *sdk.Xxx) (XxxModel, diag.Diagnostics)
+
+// SDK type → data source Terraform model
+func xxxToDataSourceModel(ctx context.Context, obj *sdk.Xxx) (XxxDataSourceModel, diag.Diagnostics)
+
+// Resource Terraform model → SDK type  (Create/Update only)
+func xxxFromModel(tenant string, data XxxModel) *sdk.Xxx
+```
+
+Rules for mapping functions:
+- `xxxFromModel` receives `tenant string` as first argument (never read tenant from the model)
+- `xxxToResourceModel` and `xxxToDataSourceModel` return `diag.Diagnostics` even if currently empty — future-proofing
+- Use shared helpers from `types.go` — do not re-implement `fromTime`, `fromRefPtr`, etc.
+- Data source models include `state` from `sdk.Status.State`; resource models do not (state is an API-side concept)
+
+## Type Conversion Helpers (`types.go`)
+
+Always use these helpers for type conversion. Never convert inline:
+
+| Helper | Input → Output | Null behavior |
+|---|---|---|
+| `fromTime(t)` | `time.Time` → `types.String` | zero time → `types.StringNull()` |
+| `fromTimePtr(t)` | `*time.Time` → `types.String` | nil or zero → `types.StringNull()` |
+| `fromRefPtr(r)` | `*sdk.Reference` → `types.String` | nil → `types.StringNull()` |
+| `fromStringMap(ctx, m)` | `map[string]string` → `(types.Map, diag.Diagnostics)` | nil/empty → null map |
+| `toStringMap(m)` | `types.Map` → `map[string]string` | null/unknown → nil |
+| `numberToDuration(n)` | `types.Number` → `time.Duration` | null/unknown → 0 |
+| `numberToInt(n)` | `types.Number` → `int` | null/unknown → 0 |
+
+## SDK Enum Casting
+
+SDK enums are string types. Cast them explicitly:
+
+```go
+// To SDK type
+sdk.ImageSpecCpuArchitecture(data.CpuArchitecture.ValueString())
+
+// From SDK type
+types.StringValue(string(image.Spec.CpuArchitecture))
+```
+
+## Unused Variables / Assignments
+
+The linter enforces `unused`, `ineffassign`. Do not assign to `_` to suppress; fix the root cause.
+
+## Comments
+
+- No multi-line or multi-paragraph comments
+- One-line comments only, and only when the WHY is non-obvious
+- The existing `// Create the block storage`, `// Wait until it is active` comments are structural separators — acceptable but do not add new ones
+- Do not add `// TODO` comments without a linked issue
+
+## Dependencies
+
+- Never add a new dependency without approval
+- Never import `terraform-plugin-sdk/v2` — the depguard linter blocks this
+- Use `go.mod`; never use `replace` directives for published modules

--- a/ai/glossary.md
+++ b/ai/glossary.md
@@ -1,0 +1,93 @@
+# Glossary
+
+Domain terminology, SDK types, and Terraform model mappings.
+
+## Domain Terms
+
+| Term | Meaning |
+|---|---|
+| **SECA** | EU Sovereign Cloud (the cloud platform this provider targets) |
+| **Tenant** | The top-level isolation boundary in SECA. All resources belong to a tenant. Equivalent to an "account" or "organization" in other clouds. |
+| **Region** | A geographic deployment of the SECA platform. Each provider block targets exactly one region. |
+| **Zone** | A sub-region availability domain within a region (e.g., zone-a, zone-b). |
+| **Workspace** | A logical grouping of resources within a tenant+region. Similar to a "project" or "namespace". |
+| **SKU** | Stock Keeping Unit — a named performance/feature tier for a resource type. E.g., `RD500` is a storage SKU. |
+| **Block Storage** | A persistent volume that can be attached to an instance. |
+| **Image** | A bootable disk image created from a block storage volume. |
+| **NIC** | Network Interface Card — the network attachment point for a compute instance. |
+| **Ref** | Short for "reference" — the fully qualified resource identifier, format `<kind>/<name>` (e.g., `block-storages/my-vol`). Stored as Terraform `id`. |
+
+## SDK Types (go-sdk)
+
+### Client Types (`secapi` package)
+
+| Type | Purpose |
+|---|---|
+| `secapi.GlobalClient` | Communicates with global endpoints (Region registry, Authorization). Shared across regions. |
+| `secapi.RegionalClient` | Communicates with a specific region's API endpoints. Derived from GlobalClient. |
+
+### Reference Types (`secapi` package)
+
+| Type | Fields | Used for |
+|---|---|---|
+| `secapi.TenantReference` | `Tenant TenantID`, `Name string` | Tenant-scoped resources (Workspace, Image, StorageSku) |
+| `secapi.WorkspaceReference` | `Tenant TenantID`, `Workspace WorkspaceID`, `Name string` | Workspace-scoped resources (BlockStorage) |
+| `secapi.TenantID` | `string` alias | Type-safe tenant identifier |
+| `secapi.WorkspaceID` | `string` alias | Type-safe workspace identifier |
+
+### Polling Type
+
+| Type | Purpose |
+|---|---|
+| `secapi.ResourceObserverUntilValueConfig[T]` | Configuration for polling: `ExpectedValues []T`, `Delay`, `Interval`, `MaxAttempts` |
+
+### Schema Types (`go-sdk/pkg/spec/schema`, aliased as `sdk`)
+
+| Type | Terraform resource | Key fields |
+|---|---|---|
+| `sdk.Region` | `seca_region` data source | `Metadata *GlobalResourceMetadata`, `Spec.AvailableZones`, `Spec.Providers` |
+| `sdk.Workspace` | `seca_workspace` | `Metadata *RegionalResourceMetadata`, `Status.State` |
+| `sdk.Image` | `seca_image` | `Metadata *RegionalResourceMetadata`, `Spec.BlockStorageRef`, `Spec.CpuArchitecture`, `Spec.Initializer`, `Spec.Boot`, `Status.State` |
+| `sdk.BlockStorage` | `seca_block_storage` | `Metadata *RegionalWorkspaceResourceMetadata`, `Spec.SizeGB`, `Spec.SkuRef`, `Spec.SourceImageRef`, `Status.State` |
+| `sdk.StorageSku` | `seca_storage_sku` data source | `Metadata *SkuResourceMetadata`, `Spec.Iops`, `Spec.Type`, `Spec.MinVolumeSize` |
+
+### Metadata Types
+
+| Type | Scope | Fields |
+|---|---|---|
+| `sdk.GlobalResourceMetadata` | Global | `Name`, `Ref`, `CreatedAt`, `DeletedAt`, `LastModifiedAt` |
+| `sdk.RegionalResourceMetadata` | Tenant | `Name`, `Ref`, `Tenant`, `Region`, `CreatedAt`, `DeletedAt`, `LastModifiedAt` |
+| `sdk.RegionalWorkspaceResourceMetadata` | Workspace | All above + `Workspace` |
+| `sdk.SkuResourceMetadata` | Tenant (SKUs) | `Name`, `Ref`, `Tenant`, `Region` (no timestamps) |
+
+### State and Enum Types
+
+| Type | Values | Used in |
+|---|---|---|
+| `sdk.ResourceState` | `ResourceStateActive`, `ResourceStateDeleted`, others | Status.State on Workspace, Image, BlockStorage |
+| `sdk.ImageSpecCpuArchitecture` | `ImageSpecCpuArchitectureAmd64`, `ImageSpecCpuArchitectureArm64` | Image spec |
+| `sdk.ImageSpecInitializer` | `ImageSpecInitializerNone`, `ImageSpecInitializerCloudinit22` | Image spec |
+| `sdk.ImageSpecBoot` | `ImageSpecBootBIOS`, `ImageSpecBootUEFI` | Image spec |
+| `sdk.StorageSkuType` | `StorageSkuTypeRemoteDurable`, others | StorageSku spec |
+| `sdk.Reference` | `{Resource string}` | Cross-resource references |
+
+## Terraform Model Types (this provider)
+
+| Suffix | Meaning |
+|---|---|
+| `XxxResource` | The resource struct implementing `resource.Resource` |
+| `XxxDataSource` | The data source struct implementing `datasource.DataSource` |
+| `XxxModel` | The Terraform state model for a resource (tfsdk-tagged struct) |
+| `XxxDataSourceModel` | The Terraform state model for a data source |
+| `xxxFromModel()` | Converts resource Terraform model → SDK type (for Create/Update) |
+| `xxxToResourceModel()` | Converts SDK type → resource Terraform model |
+| `xxxToDataSourceModel()` | Converts SDK type → data source Terraform model |
+
+## Infrastructure Terms
+
+| Term | Meaning in this codebase |
+|---|---|
+| `global_providers` | Provider config block pointing to the global API endpoints (region registry, authorization) |
+| `region_v1` | URL of the SECA Region API v1 global endpoint |
+| `authorization_v1` | URL of the SECA Authorization API v1 global endpoint |
+| `retry` | Provider config block controlling polling behavior for async resources |

--- a/ai/guardrails.md
+++ b/ai/guardrails.md
@@ -1,0 +1,99 @@
+# AI Guardrails
+
+These are hard rules. Violations will cause bugs, regressions, or data loss.
+
+## Schema
+
+**Never:**
+- Remove, rename, or change the type of an existing Required or Optional attribute — this is a breaking change for existing Terraform configurations
+- Add a `RequiresReplace()` plan modifier to an attribute that the API supports in-place updates for
+- Change `id` to anything other than `Metadata.Ref` (the full `<kind>/<name>` reference string)
+- Add `RequiresReplace()` to Computed attributes
+- Make a Computed attribute Optional+Computed without understanding whether the API will echo back the value or default it
+
+**Always:**
+- Maintain the standard attribute set (`id`, `name`, `tenant`, `region`, `created_at`, `deleted_at`, `last_modified_at`, `labels`, `annotations`, `extensions`) on every resource and data source that represents a regional resource
+- Apply `RequiresReplace()` to `name` on every resource
+- Apply `RequiresReplace()` to `workspace_id` on every workspace-scoped resource
+
+## Async Operations
+
+**Never:**
+- Write Terraform state from the result of `CreateOrUpdateXxx()` — write from the result of `GetXxxUntilState()` only
+- Skip the polling step for Create or Update
+- Use `time.Sleep()` instead of the SDK's `GetXxxUntilState()` mechanism
+- Hard-code delay or interval values — always read from resource struct retry fields
+
+**Always:**
+- Poll for `ResourceStateActive` after every Create and Update
+- Use the retry parameters from the `clients` struct (passed through from provider config)
+- Check for error from `GetXxxUntilState()` and surface it as a diagnostic
+
+## Error Handling
+
+**Never:**
+- Ignore an error from an SDK call (including during polling)
+- Use `_` to discard an error return value from an API call
+- Continue processing after `resp.Diagnostics.HasError()` returns true
+- Panic
+
+**Always:**
+- Call `resp.Diagnostics.AddError()` before every `return` on error
+- Check `HasError()` immediately after every `Diagnostics.Append()` call
+- Include `err.Error()` in the diagnostic detail string
+
+## State Management
+
+**Never:**
+- Write partial state (always write all fields or none)
+- Read from `req.State` in Create (use `req.Plan`)
+- Read from `req.Plan` in Delete or Read (use `req.State`)
+- Read from `req.State` in a data source Read (use `req.Config`)
+- Change state layout (field names, types, nesting) without a state migration
+
+**Always:**
+- Use `resp.State.Set(ctx, &data)` (pointer, not value) and append its diagnostics
+- Populate `id` from `Metadata.Ref` of the fully provisioned resource (from polling result)
+
+## Mapping Functions
+
+**Never:**
+- Re-implement logic already in `types.go` helpers (`fromTime`, `fromRefPtr`, etc.)
+- Read `tenant` from the Terraform model inside `xxxFromModel()` — always pass it as a parameter
+- Duplicate mapping logic between resource and data source models without extracting a shared helper
+
+**Always:**
+- Return `diag.Diagnostics` from `xxxToXxxModel()` functions, even if currently empty
+- Check null/unknown before calling `.ValueString()` on optional attributes
+- Cast SDK enum strings explicitly: `sdk.SomeEnum(data.Field.ValueString())`
+
+## Tests
+
+**Never:**
+- Use mocking for unit tests in this provider
+- Import `terraform-plugin-sdk/v2/helper/acctest` or `terraform-plugin-sdk/v2/helper/resource` (depguard blocks these)
+- Write acceptance tests that depend on prior test state (each test must be independently runnable)
+
+**Always:**
+- Write unit tests for every new `xxxToXxxModel()` and `xxxFromModel()` function
+- Cover null/zero/empty edge cases in unit tests
+- Write acceptance tests that verify all computed fields after create
+
+## Package and Module
+
+**Never:**
+- Create sub-packages inside `internal/provider/`
+- Import `terraform-plugin-sdk/v2` (depguard blocks this)
+- Add dependencies without review
+
+## Conventions
+
+**Never:**
+- Deviate from the established file naming convention (`resource_xxx.go`, `datasource_xxx.go`)
+- Omit the compile-time interface check (`var _ resource.Resource = (*XxxResource)(nil)`)
+- Use a different error message format than the established pattern
+
+**Always:**
+- Follow the `Configure()` guard pattern: check `req.ProviderData == nil` and type-assert to `clients`
+- Register new resources/data sources in `provider.go` `Resources()` / `DataSources()` lists
+- Run `make generate` after schema changes to keep docs in sync

--- a/ai/implementation-checklist.md
+++ b/ai/implementation-checklist.md
@@ -1,0 +1,99 @@
+# Implementation Checklist
+
+Use this checklist when implementing a new resource or data source. Complete every step in order.
+
+## Before Writing Code
+
+- [ ] Identify the resource scope: Global, Tenant, or Workspace (see [architecture.md](architecture.md#scoping-model))
+- [ ] Identify the SDK client: `GlobalClient` or `RegionalClient`
+- [ ] Identify the SDK service: e.g., `WorkspaceV1`, `StorageV1`
+- [ ] Identify the SDK methods: `CreateOrUpdateXxx`, `GetXxx`, `GetXxxUntilState`, `DeleteXxx`
+- [ ] Identify the SDK type: `*sdk.Xxx`, its `Metadata` type, and its `Spec`/`Status` types
+- [ ] List all Required, Optional, and Computed fields from the API spec
+- [ ] Determine which fields are immutable (will need `RequiresReplace()`)
+- [ ] Determine which fields the API may default or modify (will need `Optional + Computed`)
+- [ ] Read [guardrails.md](guardrails.md) before proceeding
+
+## Resource File (`internal/provider/resource_xxx.go`)
+
+- [ ] Create file named `resource_<name>.go`
+- [ ] Declare compile-time interface checks
+- [ ] Define `XxxResource` struct with: `client`, `tenant`, `region`, `retryDelay`, `retryInterval`, `retryMaxAttempts`
+- [ ] Implement `newXxxResource() resource.Resource`
+- [ ] Implement `Metadata()` — set TypeName = `providerTypeName + "_xxx"`
+- [ ] Define `XxxModel` struct with all fields (standard + resource-specific), in the correct order
+- [ ] Implement `Schema()` — include all standard attributes; add resource-specific attributes
+- [ ] Apply `RequiresReplace()` to `name` and `workspace_id`
+- [ ] Implement `Configure()` — guard nil check, type assert to `clients`, store all fields including retry
+- [ ] Implement `Create()`:
+  - Read from `req.Plan`
+  - Call `xxxFromModel(tenant, data)` to build SDK object
+  - Call `CreateOrUpdateXxx()`
+  - Build reference for polling (from API result, not model)
+  - Build `ResourceObserverUntilValueConfig` with struct retry fields
+  - Call `GetXxxUntilState()`
+  - Call `xxxToResourceModel(ctx, result)`
+  - Write state
+- [ ] Implement `Read()`:
+  - Read from `req.State`
+  - Build reference from state values
+  - Call `GetXxx()`
+  - Call `xxxToResourceModel(ctx, result)`
+  - Write state
+- [ ] Implement `Update()` — same structure as Create
+- [ ] Implement `Delete()`:
+  - Read from `req.State`
+  - Build minimal SDK object (Metadata only)
+  - Call `DeleteXxx()`
+- [ ] Implement `xxxFromModel(tenant string, data XxxModel) *sdk.Xxx`
+- [ ] Implement `xxxToResourceModel(ctx, *sdk.Xxx) (XxxModel, diag.Diagnostics)`
+
+## Data Source File (`internal/provider/datasource_xxx.go`)
+
+- [ ] Create file named `datasource_<name>.go`
+- [ ] Declare compile-time interface checks
+- [ ] Define `XxxDataSource` struct with: `client`, `tenant` (and `region` if needed)
+- [ ] Implement `newXxxDataSource() datasource.DataSource`
+- [ ] Implement `Metadata()` — set TypeName = `providerTypeName + "_xxx"`
+- [ ] Define `XxxDataSourceModel` struct (same fields as resource model + `state`)
+- [ ] Implement `Schema()` — `labels`/`annotations`/`extensions` are `Computed` (not Optional); add `state`
+- [ ] Implement `Configure()` — guard nil check, type assert, store client and tenant
+- [ ] Implement `Read()`:
+  - Read from `req.Config`
+  - Build reference from config values
+  - Call `GetXxx()`
+  - Call `xxxToDataSourceModel(ctx, result)`
+  - Write state
+- [ ] Implement `xxxToDataSourceModel(ctx, *sdk.Xxx) (XxxDataSourceModel, diag.Diagnostics)` — include `State` from status
+
+## Registration
+
+- [ ] Add `newXxxResource` to `Resources()` list in `provider.go`
+- [ ] Add `newXxxDataSource` to `DataSources()` list in `provider.go`
+
+## Unit Tests (`internal/provider/resource_xxx_test.go`)
+
+- [ ] Create file named `resource_<name>_test.go` for `TestXxxToResourceModel`
+- [ ] Create file named `datasource_<name>_test.go` for `TestXxxToDataSourceModel`
+- [ ] Build a fully-populated SDK object
+- [ ] Include `DeletedAt` as non-nil (tests nullable pointer)
+- [ ] Include non-empty `Labels`, `Annotations`, `Extensions`
+- [ ] Assert every field in the resulting model
+- [ ] Assert `IsNull()` for absent optional pointer fields (separate test case)
+- [ ] Assert the `state` field for data source tests
+
+## Acceptance Tests (`internal/acctest/<name>_test.go`)
+
+- [ ] Create file named `<name>_test.go` in `internal/acctest/`
+- [ ] Define `testAcc<Name>ResourceConfig() string`
+- [ ] Define `testAcc<Name>DataSourceConfig() string`
+- [ ] Implement `TestAcc<Name>` with at minimum:
+  - Step 1: Create resource; check all non-computed fields are set correctly; check tenant and region
+  - Step 2: Create resource + data source; check data source reads resource; check `state = "active"`
+
+## Documentation
+
+- [ ] Add example HCL in `examples/resources/seca_<name>/resource.tf`
+- [ ] Add example HCL in `examples/data-sources/seca_<name>/data-source.tf`
+- [ ] Run `make generate` to regenerate `docs/`
+- [ ] Verify generated docs look correct

--- a/ai/known-issues.md
+++ b/ai/known-issues.md
@@ -1,0 +1,125 @@
+# Known Issues and Technical Debt
+
+This document captures observed technical debt and known issues. **Do not fix these without a tracked issue and review.** The purpose of documenting them here is to ensure AI agents do not accidentally work around or worsen these problems.
+
+## Critical Gaps
+
+### 1. No `ImportState` Implementation
+
+**Impact:** Users cannot import existing SECA resources into Terraform state (`terraform import`).
+
+**All resources affected:** `seca_workspace`, `seca_image`, `seca_block_storage`
+
+**What's missing:** None of the resource structs implement `resource.ResourceWithImportState`. The framework's `resource.ImportStatePassthroughID()` would be the minimal implementation for name-based imports.
+
+**Risk of workaround:** Do not add `ImportState` unless the SECA API can look up a resource by its `Metadata.Ref` string. Verify the SDK supports `GetXxx(ref)` where ref is the full `<kind>/<name>` string.
+
+---
+
+### 2. No 404 Handling in `Read()`
+
+**Impact:** If a resource is deleted out-of-band (outside Terraform), `Read()` will return an error diagnostic instead of removing the resource from state. Terraform will keep trying to refresh a non-existent resource.
+
+**All resources affected:** `seca_workspace`, `seca_image`, `seca_block_storage`
+
+**Correct behavior:** When `GetXxx()` returns a not-found error, call `resp.State.RemoveResource(ctx)` and return without error.
+
+**Risk of workaround:** Must identify how the SDK signals a 404 (error type or error message pattern) before implementing.
+
+---
+
+### 3. Delete Does Not Poll for Completion
+
+**Impact:** Terraform considers a resource deleted as soon as `DeleteXxx()` returns without error, but the resource may still be deleting on the API side. A subsequent create of a same-named resource may conflict.
+
+**All resources affected:** `seca_workspace`, `seca_image`, `seca_block_storage`
+
+**Correct behavior:** Poll `GetXxxUntilState()` with a "deleted" terminal state, or poll until a 404 is returned.
+
+---
+
+### 4. Copy-Paste Error in `resource_workspace.go` Create()
+
+**Location:** `internal/provider/resource_workspace.go:168`
+
+**Problem:** The error diagnostic for the polling step in `Create()` says `"Error updating workspace"` instead of `"Error creating workspace"`.
+
+```go
+// Bug: says "updating" in a Create() method
+resp.Diagnostics.AddError(
+    "Error updating workspace",   // ← should be "Error creating workspace"
+    ...
+)
+```
+
+---
+
+## Design Gaps
+
+### 5. Duplicated Mapping Logic Between Resource and Data Source
+
+**Impact:** Every resource has both `xxxToResourceModel` and `xxxToDataSourceModel` with nearly identical code. The only difference is that data source models include `state` from status and use `Computed` for maps.
+
+**Example:** `blockStorageToResourceModel` and `blockStorageToDataSourceModel` share ~80% identical mapping code.
+
+**Future improvement:** Extract a shared mapping for common fields (metadata, labels, timestamps), then add resource/data source-specific fields on top.
+
+---
+
+### 6. No `UseStateForUnknown()` on Computed Fields
+
+**Impact:** On every plan, all Computed fields (`tenant`, `region`, `created_at`, etc.) show as `(known after apply)` even when no change is expected. This produces noisy plans and erodes user trust.
+
+**What's missing:** `planmodifier.UseStateForUnknown()` should be added to Computed fields that will not change after initial creation.
+
+---
+
+### 7. Retry Config Is Coarse-Grained
+
+**Impact:** All resources in a provider instance share the same retry config. A slow-provisioning instance and a fast-provisioning workspace cannot have different polling configs.
+
+**Current behavior:** `retry.delay`, `retry.interval`, `retry.max_attempts` are provider-level only.
+
+**Future improvement:** Consider per-resource `timeouts` blocks using `timeouts.New()` from the framework.
+
+---
+
+### 8. No Structured Logging (`tflog`)
+
+**Impact:** No debug output when `TF_LOG=DEBUG` is set. Debugging API interactions requires network tracing.
+
+**What's missing:** `tflog.Debug(ctx, "...")` calls in Create, Read, Update, Delete, and Configure.
+
+---
+
+### 9. `StorageSkuDataSource` Missing `created_at` / `deleted_at` / `last_modified_at`
+
+**Location:** `internal/provider/datasource_storage_sku.go`
+
+**Problem:** The `StorageSku` SDK type uses `SkuResourceMetadata` which may not have the same timestamp fields as `RegionalResourceMetadata`. The schema omits these fields entirely. This is inconsistent with other data sources.
+
+**Risk:** If `SkuResourceMetadata` gains timestamps, the schema is not ready to expose them.
+
+---
+
+### 10. Acceptance Test Cluster Is Hard-Coded
+
+**Location:** `internal/acctest/provider_test.go`
+
+**Problem:** The cluster endpoints (`172.18.0.2:30081`) are hard-coded. Running acceptance tests against a different cluster requires editing source code.
+
+**Improvement:** Read endpoints from environment variables (`SECA_REGION_ENDPOINT`, `SECA_AUTH_ENDPOINT`, etc.).
+
+---
+
+### 11. No Update Acceptance Test Steps
+
+**Impact:** No acceptance test verifies that updating a resource's mutable fields (e.g., `size_gb` on block storage, `labels`) is reflected correctly.
+
+**All resources affected:** `seca_workspace`, `seca_image`, `seca_block_storage`
+
+---
+
+### 12. No `CheckDestroy` in Acceptance Tests
+
+**Impact:** Acceptance tests do not verify that resources are actually deleted from the API after `terraform destroy`. The framework's automatic cleanup may succeed at the provider level while leaving orphaned resources on the API.

--- a/ai/prompts/bugfix.md
+++ b/ai/prompts/bugfix.md
@@ -1,0 +1,44 @@
+# Prompt: Bug Fix
+
+Use this prompt when investigating and fixing a reported bug.
+
+---
+
+## Prompt
+
+```
+You are fixing a bug in the terraform-provider-seca repository.
+
+Read these documents before making any changes:
+- ai/architecture.md — understand the code structure
+- ai/async-operations.md — common source of bugs
+- ai/guardrails.md — rules you must not break while fixing
+- ai/known-issues.md — check if this bug is a known issue before attempting a fix
+
+## Bug Report
+
+[Describe the bug, error messages, and reproduction steps]
+
+## Investigation Steps
+
+1. Identify the affected resource or data source
+2. Determine which CRUD method is involved (Create/Read/Update/Delete)
+3. Check the mapping functions (xxxToModel, xxxFromModel) for the affected fields
+4. Check if the bug is related to async polling (state written from wrong source)
+5. Check if the bug is related to null/unknown handling
+6. Check if the bug is a known issue in ai/known-issues.md
+
+## Fix Constraints
+
+- Do not change schema attribute names, types, or required/optional status unless the bug IS the schema being wrong
+- Do not change state layout (field ordering, nesting) without adding a state migration
+- Do not skip the polling step as a "quick fix" for async issues
+- Do not add a workaround for a known issue — fix it properly or leave it and document it
+- After fixing, verify the fix does not introduce any item in ai/guardrails.md
+
+## Testing the Fix
+
+- Add or update the relevant unit test in internal/provider/ to cover the bug case
+- If the bug is reproducing in acceptance tests, add a test step that would have caught it
+- Run: go test -v -run TestXxx ./internal/provider/
+```

--- a/ai/prompts/feature.md
+++ b/ai/prompts/feature.md
@@ -1,0 +1,62 @@
+# Prompt: Add a Feature to an Existing Resource
+
+Use this prompt when extending an existing resource or data source with new functionality (new attributes, import support, plan modifiers, validators, etc.).
+
+---
+
+## Prompt
+
+```
+You are adding a feature to an existing resource in the terraform-provider-seca repository.
+
+Read these documents before making any changes:
+- ai/guardrails.md — hard constraints on schema changes
+- ai/terraform-framework.md — framework features and how they're used in this provider
+- ai/provider-conventions.md — naming and schema conventions
+- ai/known-issues.md — check if the feature you're adding addresses a known issue
+
+## Feature Request
+
+[Describe the feature: what resource, what new behavior, why]
+
+## Schema Change Rules
+
+Adding attributes:
+- Adding Computed attributes is always safe (additive, no breaking change)
+- Adding Optional attributes requires setting a reasonable zero/empty default so existing configs continue to work
+- Adding Required attributes is ALWAYS a breaking change — do not do it without a major version bump
+
+Changing attributes:
+- NEVER change the type of an existing attribute
+- NEVER change Optional to Required
+- NEVER rename an attribute
+- Adding RequiresReplace() to an attribute that did not have it is a breaking change
+
+Removing attributes:
+- NEVER remove an existing attribute without a deprecation period and state migration
+
+## Adding ImportState
+
+If adding ImportState to an existing resource:
+1. Implement resource.ResourceWithImportState on the resource struct
+2. Use the resource's `name` as the import ID (verify the API can look up by name)
+3. Implement ImportState to call resource.ImportStatePassthroughID() if name = id, or populate state manually
+4. Add an acceptance test step with ImportState: true, ImportStateVerify: true
+5. Update ai/known-issues.md to remove the relevant known issue entry
+
+## Adding UseStateForUnknown()
+
+If adding UseStateForUnknown() to Computed fields:
+1. Only add to fields that will NOT change after initial provisioning (tenant, region, created_at)
+2. Do NOT add to fields that the API may update (last_modified_at, state)
+3. Import both resource/schema/planmodifier and datasource/schema/planmodifier as needed
+
+## Verification
+
+After implementing:
+1. Run: go build ./...
+2. Run: go test -v -cover ./...
+3. Run: make lint
+4. Run: make generate (if schema changed)
+5. Verify review-checklist.md is satisfied
+```

--- a/ai/prompts/implementation.md
+++ b/ai/prompts/implementation.md
@@ -1,0 +1,81 @@
+# Prompt: Implement a New Resource or Data Source
+
+Use this prompt when implementing a new Terraform resource or data source in this provider.
+
+---
+
+## Context to Provide
+
+Before using this prompt, gather:
+1. The Terraform resource name (e.g., `seca_network`)
+2. The SDK type name (e.g., `sdk.Network`)
+3. The SDK service on RegionalClient or GlobalClient (e.g., `NetworkV1`)
+4. The available SDK methods (CreateOrUpdate, Get, GetUntilState, Delete)
+5. The resource scope: Global, Tenant, or Workspace
+6. The SDK Metadata type (e.g., `sdk.RegionalResourceMetadata`)
+7. The list of spec fields with their types
+
+---
+
+## Prompt
+
+```
+You are implementing a new Terraform resource/data source for the terraform-provider-seca repository.
+
+Read these documents before writing any code:
+- ai/architecture.md — understand the package structure and client model
+- ai/provider-conventions.md — naming, schema patterns, Configure() pattern
+- ai/async-operations.md — the mandatory Create/Update polling pattern
+- ai/coding-guidelines.md — formatting, imports, error messages
+- ai/guardrails.md — rules you must not break
+- ai/implementation-checklist.md — complete every item on this checklist
+
+## Task
+
+Implement [resource/data source]: seca_<name>
+
+## Resource Details
+
+- Terraform name: seca_<name>
+- SDK type: sdk.<Name>
+- SDK service: [RegionalClient/GlobalClient].<ServiceV1>
+- SDK methods:
+  - Create/Update: <service>.CreateOrUpdate<Name>()
+  - Read: <service>.Get<Name>()
+  - Poll: <service>.Get<Name>UntilState()
+  - Delete: <service>.Delete<Name>()
+- Resource scope: [Global/Tenant/Workspace]
+- Metadata type: sdk.<MetadataType>
+- Reference type for SDK calls: secapi.[TenantReference/WorkspaceReference]
+
+## Spec Fields
+
+| Field | SDK type | Required/Optional/Computed |
+|---|---|---|
+| <field_name> | <sdk_type> | <classification> |
+
+## Files to Create
+
+1. internal/provider/resource_<name>.go
+2. internal/provider/datasource_<name>.go (if a data source is also needed)
+3. internal/provider/resource_<name>_test.go
+4. internal/provider/datasource_<name>_test.go (if data source)
+5. internal/acctest/<name>_test.go
+6. examples/resources/seca_<name>/resource.tf
+7. examples/data-sources/seca_<name>/data-source.tf
+
+## Files to Modify
+
+- internal/provider/provider.go — add to Resources() and/or DataSources()
+
+## Constraints
+
+- Follow the existing file structure exactly (see internal/provider/resource_block_storage.go as the primary reference)
+- Do not use terraform-plugin-sdk/v2
+- Do not skip the polling step in Create() or Update()
+- Write state from the GetXxxUntilState() result, never from CreateOrUpdateXxx()
+- Apply RequiresReplace() to name and workspace_id (if workspace-scoped)
+- Use retry fields from the resource struct, never hard-code values
+- Use helpers from types.go — do not re-implement fromTime, fromRefPtr, etc.
+- After implementing, verify the implementation-checklist.md is fully satisfied
+```

--- a/ai/prompts/refactor.md
+++ b/ai/prompts/refactor.md
@@ -1,0 +1,49 @@
+# Prompt: Refactor
+
+Use this prompt when refactoring existing code for maintainability, deduplication, or consistency.
+
+---
+
+## Prompt
+
+```
+You are refactoring code in the terraform-provider-seca repository.
+
+Read these documents before making any changes:
+- ai/guardrails.md — rules you must not break
+- ai/architecture.md — understand what should and should not change
+- ai/known-issues.md — the items listed here are candidates for improvement, but each requires care
+- ai/coding-guidelines.md — conventions to maintain
+
+## Refactor Scope
+
+[Describe what you want to refactor and why]
+
+## Hard Constraints
+
+You must not:
+- Change any attribute name, type, required/optional status, or computed status in any schema
+- Remove or rename any public type (XxxResource, XxxModel, etc.) — these are used by the framework
+- Change the signature of any method required by the framework (Metadata, Schema, Configure, Create, Read, Update, Delete)
+- Change the state layout (field names, types, nesting) without a state upgrader
+- Introduce new external dependencies
+- Create sub-packages inside internal/provider/
+
+## Safe Refactoring Targets
+
+The following refactors are safe if they do not violate the constraints above:
+- Extracting common metadata mapping into a shared function
+- Extracting the retry config pattern into a shared Configure helper
+- Reducing duplication between xxxToResourceModel and xxxToDataSourceModel
+- Improving error message consistency
+- Adding missing UseStateForUnknown() plan modifiers to Computed fields (non-breaking addition)
+
+## Verification
+
+After refactoring:
+1. Run: go build ./...
+2. Run: go test -v -cover ./...
+3. Run: make lint
+4. Confirm all items in ai/review-checklist.md still pass
+5. Confirm no items in ai/guardrails.md are violated
+```

--- a/ai/prompts/review.md
+++ b/ai/prompts/review.md
@@ -1,0 +1,47 @@
+# Prompt: Code Review
+
+Use this prompt to review a PR or diff for correctness, convention compliance, and safety.
+
+---
+
+## Prompt
+
+```
+You are performing a code review for the terraform-provider-seca repository.
+
+Read these documents before reviewing:
+- ai/guardrails.md — hard rules; any violation is a blocker
+- ai/review-checklist.md — work through every item on this checklist
+- ai/provider-conventions.md — naming and schema conventions
+- ai/async-operations.md — the mandatory polling pattern
+- ai/testing-strategy.md — what tests are required
+
+## Review Scope
+
+[Paste the diff or describe the PR here]
+
+## Review Instructions
+
+1. Work through ai/review-checklist.md item by item. Mark each as:
+   - PASS — satisfied
+   - FAIL — violated (explain why and what the correct implementation is)
+   - N/A — not applicable to this change
+
+2. After the checklist, provide a summary section with:
+   - Blockers (must fix before merge)
+   - Suggestions (improvements that are not blocking)
+   - Praise (good patterns worth noting)
+
+3. For each FAIL, provide a concrete code example of the correct implementation.
+
+## Focus Areas
+
+Pay special attention to:
+- Is state populated from the GetXxxUntilState() result (not CreateOrUpdateXxx())?
+- Does Read() read from req.State (not req.Plan)?
+- Is there a HasError() check after every Diagnostics.Append()?
+- Is tenant passed as a parameter to xxxFromModel() rather than read from the model?
+- Are unit tests present for all new mapping functions?
+- Are null/zero/empty edge cases covered in unit tests?
+- Are any terraform-plugin-sdk/v2 packages imported?
+```

--- a/ai/provider-conventions.md
+++ b/ai/provider-conventions.md
@@ -1,0 +1,161 @@
+# Provider Conventions
+
+This document captures every naming, schema, and structural convention observed across the existing implementation. New resources and data sources must follow these conventions exactly.
+
+## File Naming
+
+| Type | File name pattern |
+|---|---|
+| Resource | `resource_<name>.go` |
+| Data source | `datasource_<name>.go` |
+| Resource unit test | `resource_<name>_test.go` |
+| Data source unit test | `datasource_<name>_test.go` |
+
+Acceptance tests live in `internal/acctest/` as `<name>_test.go`.
+
+## Type Naming
+
+| Purpose | Naming pattern | Example |
+|---|---|---|
+| Resource struct | `<Name>Resource` | `BlockStorageResource` |
+| Data source struct | `<Name>DataSource` | `BlockStorageDataSource` |
+| Resource model | `<Name>Model` | `BlockStorageModel` |
+| Data source model | `<Name>DataSourceModel` | `BlockStorageDataSourceModel` |
+| Constructor (resource) | `new<Name>Resource()` | `newBlockStorageResource()` |
+| Constructor (data source) | `new<Name>DataSource()` | `newBlockStorageDataSource()` |
+| Model→SDK mapper | `<name>FromModel(tenant, data)` | `blockStorageFromModel()` |
+| SDK→resource model | `<name>ToResourceModel(ctx, sdk)` | `blockStorageToResourceModel()` |
+| SDK→data source model | `<name>ToDataSourceModel(ctx, sdk)` | `blockStorageToDataSourceModel()` |
+
+## Interface Compliance
+
+Every resource and data source file must declare compile-time interface checks:
+
+```go
+var (
+    _ resource.Resource              = (*BlockStorageResource)(nil)
+    _ resource.ResourceWithConfigure = (*BlockStorageResource)(nil)
+)
+```
+
+For data sources:
+```go
+var (
+    _ datasource.DataSource              = (*BlockStorageDataSource)(nil)
+    _ datasource.DataSourceWithConfigure = (*BlockStorageDataSource)(nil)
+)
+```
+
+## TypeName Convention
+
+```go
+func (r *BlockStorageResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+    resp.TypeName = req.ProviderTypeName + "_block_storage"
+}
+```
+
+The suffix is always snake_case matching the Terraform resource name.
+
+## Standard Schema Attributes
+
+Every resource schema must include these attributes in this order:
+
+```go
+"id":               Computed: true  (populated from Metadata.Ref)
+"name":             Required: true + RequiresReplace()  (immutable API identifier)
+"tenant":           Computed: true  (from provider config, read-only)
+"region":           Computed: true  (from provider config, read-only)
+"created_at":       Computed: true  (RFC3339 string)
+"deleted_at":       Computed: true  (RFC3339 string, nullable)
+"last_modified_at": Computed: true  (RFC3339 string)
+"labels":           Optional: true  + MapAttribute{ElementType: types.StringType}
+"annotations":      Optional: true  + MapAttribute{ElementType: types.StringType}
+"extensions":       Optional: true  + MapAttribute{ElementType: types.StringType}
+```
+
+Workspace-scoped resources add:
+```go
+"workspace_id": Required: true + RequiresReplace()
+```
+
+Data source schemas follow the same pattern with these differences:
+- `labels`, `annotations`, `extensions` are `Computed: true` (not Optional)
+- Resource-specific status fields (e.g., `state`) are added as `Computed: true`
+- `workspace_id` on data sources is `Required: true` without `RequiresReplace()`
+
+## ForceNew / RequiresReplace Rules
+
+`stringplanmodifier.RequiresReplace()` is applied when changing the field would require destroying and recreating the resource at the API level:
+
+- `name` — always RequiresReplace (SECA resource names are immutable identifiers)
+- `workspace_id` — always RequiresReplace (resources cannot move workspaces)
+- Other immutable spec fields — add RequiresReplace with a comment explaining the API constraint
+
+Never add RequiresReplace to Computed fields or to fields that the API supports in-place updates for.
+
+## Model Field Ordering
+
+Within a model struct, follow this ordering convention:
+1. `Id`
+2. `Name`
+3. `WorkspaceId` (if workspace-scoped)
+4. `Tenant`, `Region`
+5. `CreatedAt`, `DeletedAt`, `LastModifiedAt`
+6. `Labels`, `Annotations`, `Extensions`
+7. Resource-specific spec fields
+8. Status fields (data sources only)
+
+## Configure() Pattern
+
+Every resource and data source Configure() must:
+
+```go
+func (r *XxxResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+    if req.ProviderData == nil {
+        return  // called before provider.Configure(); safe to ignore
+    }
+
+    clients, ok := req.ProviderData.(clients)
+    if !ok {
+        resp.Diagnostics.AddError(
+            "Unexpected provider data type",
+            fmt.Sprintf("Expected sdk.Clients, got: %T", req.ProviderData),
+        )
+        return
+    }
+
+    r.client = clients.RegionalClient  // or GlobalClient for global resources
+    r.tenant = clients.Tenant
+    r.region = clients.Region
+    r.retryDelay = clients.RetryDelay
+    r.retryInterval = clients.RetryInterval
+    r.retryMaxAttempts = clients.RetryMaxAttempts
+}
+```
+
+Data sources that do not perform async operations do not need the retry fields.
+
+## Diagnostic Error Messages
+
+Error messages follow a two-part convention:
+- **Summary**: `"Error <verb>ing <resource type>"` — e.g., `"Error creating block storage"`
+- **Detail**: `"An error was encountered when <verb>ing the <resource type>.\nError: " + err.Error()`
+
+For polling errors:
+- **Summary**: `"Error <verb>ing <resource type>"`
+- **Detail**: `"An error was encountered while waiting for the <resource type> to become active.\nError: " + err.Error()`
+
+## id Field Value
+
+`id` is always set to `Metadata.Ref`, which is the full `<kind>/<name>` reference string returned by the API (e.g., `"block-storages/my-vol"`). Never set `id` to just the name.
+
+## Tenant Handling
+
+Tenant is sourced from provider config and passed to resources via `clients.Tenant`. It is:
+- Never read from the Terraform config by resources (it is always Computed)
+- Always injected into the `Metadata.Tenant` field when building SDK objects in `xxxFromModel()`
+- Always passed as the first argument to `xxxFromModel(tenant string, data Model)`
+
+## Import Note
+
+`ImportState` is not currently implemented in any resource. See [known-issues.md](known-issues.md).

--- a/ai/requirements.md
+++ b/ai/requirements.md
@@ -1,0 +1,64 @@
+# Requirements
+
+## Version Matrix
+
+| Component | Version |
+|---|---|
+| Go | `1.26.4` (see `go.mod`) |
+| Terraform Plugin Framework | `v1.19.0` |
+| Terraform Plugin Testing | `v1.16.0` |
+| go-sdk | `v0.4.2` |
+| Supported Terraform CLI | `1.13.*`, `1.14.*` (CI matrix in `.github/workflows/test.yml`) |
+| Registry address | `registry.terraform.io/eu-sovereign-cloud/seca` |
+
+**Do not use `terraform-plugin-sdk/v2`** for any new code. The `depguard` linter enforces this.
+
+## Provider Goals
+
+The SECA provider exposes the EU Sovereign Cloud (SECA) platform as Terraform-managed infrastructure. It wraps the `go-sdk` and presents SECA concepts as Terraform resources and data sources, handling:
+
+- Authentication via bearer token
+- Regional resource routing through the GlobalClient → RegionalClient bootstrap
+- Async provisioning — every mutating API call is eventually consistent; the provider polls until resources reach `Active` state
+
+## Provider Non-Goals
+
+- No multi-region resources within a single provider block (each provider block targets exactly one `region`)
+- No sub-tenant isolation — `tenant` comes from provider config and is immutable per provider instance
+- No cross-tenant references — all `tenant` fields in resource models are read-only (computed from provider config)
+- No Terraform state migration compatibility between major versions of the SECA API
+
+## Supported Resources
+
+| Resource | API client | Scope |
+|---|---|---|
+| `seca_workspace` | `RegionalClient.WorkspaceV1` | Tenant |
+| `seca_image` | `RegionalClient.StorageV1` | Tenant |
+| `seca_block_storage` | `RegionalClient.StorageV1` | Workspace |
+
+## Supported Data Sources
+
+| Data Source | API client | Scope |
+|---|---|---|
+| `seca_region` | `GlobalClient.RegionV1` | Global |
+| `seca_workspace` | `RegionalClient.WorkspaceV1` | Tenant |
+| `seca_image` | `RegionalClient.StorageV1` | Tenant |
+| `seca_block_storage` | `RegionalClient.StorageV1` | Workspace |
+| `seca_storage_sku` | `RegionalClient.StorageV1` | Tenant |
+
+## Planned but Not Yet Implemented
+
+See [roadmap.md](roadmap.md) for the full list.
+
+## Backward Compatibility Policy
+
+- Schema attributes that are `Required` or `Optional` must never be removed or have their type changed in a minor release without a state migration.
+- Computed attributes may be added freely (they are additive and do not break existing configurations).
+- `name` is used as the resource identifier in the SECA API and is always `RequiresReplace` — renaming a resource destroys and recreates it.
+- All API resource references use the `<kind>/<name>` format (e.g., `block-storages/my-vol`). This format must be preserved in Terraform `id` values.
+
+## Compatibility Guarantees
+
+- The provider targets Terraform `>= 1.13`.
+- Protocol version is 6 (`tfprotov6`), served via `providerserver.NewProtocol6WithError`.
+- Binary is built with `CGO_ENABLED=0` for static linking.

--- a/ai/review-checklist.md
+++ b/ai/review-checklist.md
@@ -1,0 +1,93 @@
+# Review Checklist
+
+Use this checklist when reviewing any PR that adds or modifies provider code.
+
+## Architecture
+
+- [ ] New files follow the naming convention (`resource_xxx.go`, `datasource_xxx.go`)
+- [ ] All provider code is in `internal/provider/` (flat, no sub-packages)
+- [ ] New resources are registered in `provider.go` `Resources()` list
+- [ ] New data sources are registered in `provider.go` `DataSources()` list
+- [ ] Acceptance tests are in `internal/acctest/` under `package acctest`
+
+## Terraform Plugin Framework
+
+- [ ] Compile-time interface checks are present (`var _ resource.Resource = (*XxxResource)(nil)`)
+- [ ] `Configure()` checks for `req.ProviderData == nil` before type assertion
+- [ ] `Configure()` type-asserts to `clients` (not a pointer) and reports error on failure
+- [ ] Create reads from `req.Plan`, not `req.State`
+- [ ] Read reads from `req.State`, not `req.Plan`
+- [ ] Update reads from `req.Plan`, not `req.State`
+- [ ] Delete reads from `req.State`, not `req.Plan`
+- [ ] Data source Read reads from `req.Config`, not `req.State`
+- [ ] `resp.State.Set(ctx, &data)` uses a pointer and its diagnostics are appended
+
+## Schema Design
+
+- [ ] Standard attributes present: `id` (Computed), `name` (Required + RequiresReplace), `tenant` (Computed), `region` (Computed), `created_at` (Computed), `deleted_at` (Computed), `last_modified_at` (Computed)
+- [ ] `labels`, `annotations`, `extensions` are `Optional` on resources, `Computed` on data sources
+- [ ] `workspace_id` on workspace-scoped resources is `Required + RequiresReplace`
+- [ ] `id` is always `Computed: true`
+- [ ] No `RequiresReplace()` on Computed attributes
+- [ ] `RequiresReplace()` is only used for attributes the API does not support in-place updates for
+- [ ] Data source schemas include a `state` field for resources with a status
+
+## Async Operations
+
+- [ ] Create calls `GetXxxUntilState()` after `CreateOrUpdateXxx()`
+- [ ] Update calls `GetXxxUntilState()` after `CreateOrUpdateXxx()`
+- [ ] State is populated from the **polling result**, not the initial create/update response
+- [ ] The `ResourceObserverUntilValueConfig` uses the resource struct's retry fields (not hard-coded values)
+- [ ] The reference for polling is built from the API result, not the Terraform model
+- [ ] Both the initial call error and the polling error are handled and surfaced as diagnostics
+
+## Error Handling
+
+- [ ] Every SDK call error results in `resp.Diagnostics.AddError()` + `return`
+- [ ] `resp.Diagnostics.HasError()` is checked after every `Diagnostics.Append()`
+- [ ] No error is silently discarded (`_ = err` is absent)
+- [ ] Error summary follows: `"Error <verb>ing <resource type>"`
+- [ ] Error detail follows: `"An error was encountered when <verb>ing...\nError: "+err.Error()`
+- [ ] Polling error detail: `"...while waiting for the <resource type> to become active.\nError: "+err.Error()`
+
+## Mapping Functions
+
+- [ ] `xxxFromModel(tenant string, data XxxModel)` receives tenant as parameter (not from model)
+- [ ] `xxxToResourceModel` and `xxxToDataSourceModel` return `diag.Diagnostics`
+- [ ] All type conversion uses helpers from `types.go`, not inline conversions
+- [ ] Optional pointer fields use `IsNull() && IsUnknown()` guard before setting
+- [ ] `id` is set from `Metadata.Ref`, not from `Metadata.Name`
+- [ ] SDK enum fields are cast: `sdk.SomeEnum(data.Field.ValueString())`
+- [ ] Resource model does NOT include `state` (data source model does)
+- [ ] Data source model mappers do NOT inline resource model mappers — they are separate functions
+
+## State Management
+
+- [ ] No backwards-incompatible schema changes (removed/renamed/retyped attributes)
+- [ ] If schema layout changed: state upgrader is implemented
+- [ ] `deleted_at` uses `fromTimePtr()` (nullable) not `fromTime()`
+
+## Go Code Quality
+
+- [ ] `gofumpt` formatting (run `make fmt` to verify)
+- [ ] No `terraform-plugin-sdk/v2` imports
+- [ ] `context.Context` is passed to every SDK call (not `context.Background()`)
+- [ ] No `time.Sleep()` calls
+- [ ] No `panic()` calls
+- [ ] Linter passes (`make lint`)
+
+## Tests
+
+- [ ] Unit test for `xxxToResourceModel` present and covers all fields
+- [ ] Unit test for `xxxToDataSourceModel` present and covers all fields including status
+- [ ] Unit tests cover null/zero/empty cases for all nullable fields
+- [ ] Acceptance test present in `internal/acctest/`
+- [ ] Acceptance test uses `testAccProtoV6ProviderFactories` and `testAccPreCheck`
+- [ ] Acceptance test uses `resource.ComposeAggregateTestCheckFunc`
+- [ ] No `terraform-plugin-sdk/v2` test helpers imported
+
+## Documentation
+
+- [ ] `make generate` was run after schema changes
+- [ ] Docs in `docs/` match the current schema
+- [ ] Example `.tf` files in `examples/` are valid and formatted (`terraform fmt`)

--- a/ai/roadmap.md
+++ b/ai/roadmap.md
@@ -1,0 +1,76 @@
+# Roadmap
+
+This document captures planned resources and features. It is derived from the `examples/use-cases/usage.tf` file, which shows the intended full usage of the provider, and from the `examples/data-sources/` and `examples/resources/` directories.
+
+## Currently Implemented
+
+| Type | Name | API Service |
+|---|---|---|
+| Resource | `seca_workspace` | `WorkspaceV1` |
+| Resource | `seca_image` | `StorageV1` |
+| Resource | `seca_block_storage` | `StorageV1` |
+| Data source | `seca_region` | `RegionV1` (global) |
+| Data source | `seca_workspace` | `WorkspaceV1` |
+| Data source | `seca_image` | `StorageV1` |
+| Data source | `seca_block_storage` | `StorageV1` |
+| Data source | `seca_storage_sku` | `StorageV1` |
+
+## Planned Resources
+
+These resources appear in `examples/` and `examples/use-cases/usage.tf` but are not yet implemented. They represent the intended full scope of the provider.
+
+### Compute
+
+| Type | Name | Notes |
+|---|---|---|
+| Resource | `seca_instance` | Has `boot_volume`, `primary_nic_id`, `ssh_keys`, `zone`, `sku_id` |
+| Data source | `seca_instance` | Read-only view of an instance |
+| Data source | `seca_instance_sku` | Discover available instance SKUs |
+
+### Networking
+
+| Type | Name | Notes |
+|---|---|---|
+| Resource | `seca_network` | Has `sku_id`, `cidr.ipv4` |
+| Resource | `seca_subnet` | Has `network_id`, `cidr.ipv4`, `route_table_id` |
+| Resource | `seca_route_table` | Has `network_id`, `routes` list (destination + target) |
+| Resource | `seca_internet_gateway` | Workspace-scoped |
+| Resource | `seca_security_group` | Has `rules` list with direction, protocol, ports, source_refs |
+| Resource | `seca_public_ip` | Has `version` (IPv4/IPv6) |
+| Resource | `seca_nic` | Has `subnet_id`, `addresses`, `public_ip_id` |
+| Data source | `seca_network` | Read-only view |
+| Data source | `seca_network_sku` | Discover available network SKUs |
+| Data source | `seca_internet_gateway` | Read-only view |
+| Data source | `seca_security_group` | Read-only view |
+| Data source | `seca_subnet` | Read-only view |
+| Data source | `seca_route_table` | Read-only view |
+| Data source | `seca_public_ip` | Read-only view |
+| Data source | `seca_nic` | Read-only view |
+
+### Authorization
+
+| Type | Name | Notes |
+|---|---|---|
+| Resource | `seca_role` | Uses `GlobalClient.AuthorizationV1` |
+| Resource | `seca_role_assignment` | Uses `GlobalClient.AuthorizationV1` |
+| Data source | `seca_role` | Read-only view |
+| Data source | `seca_role_assignment` | Read-only view |
+
+### Infrastructure Debt (Planned Improvements)
+
+See [known-issues.md](known-issues.md) for the full list. Priority items:
+
+1. **ImportState** — all existing resources need it before the provider can be considered production-ready
+2. **404 handling in Read** — necessary for drift detection and out-of-band deletions
+3. **Delete polling** — necessary to prevent race conditions on recreate
+4. **Acceptance test endpoints from env vars** — necessary for CI/CD against different environments
+5. **`UseStateForUnknown()`** — quality of life improvement for Terraform plans
+
+## Implementation Priority Notes
+
+When implementing networking resources, note that:
+- `seca_network` must exist before `seca_subnet`, `seca_route_table`
+- `seca_internet_gateway` is referenced as a route target
+- `seca_security_group.rules` uses a nested list of objects — reference the `seca_region.providers` pattern in `datasource_region.go`
+
+Authorization resources use `GlobalClient.AuthorizationV1`, not `RegionalClient`. The `RegionDataSource` is the only current example of using `GlobalClient`.

--- a/ai/terraform-framework.md
+++ b/ai/terraform-framework.md
@@ -1,0 +1,143 @@
+# Terraform Plugin Framework Usage
+
+This document captures how the Terraform Plugin Framework (`terraform-plugin-framework v1.19.0`) is used in this provider. It is not a rehash of the official docs — it focuses on decisions and patterns specific to this codebase.
+
+## Framework Version and Protocol
+
+- Framework: `github.com/hashicorp/terraform-plugin-framework v1.19.0`
+- Protocol version: 6 (via `providerserver.NewProtocol6WithError`)
+- Provider registration: `providerserver.Serve()` in `main.go` with `Address: "registry.terraform.io/eu-sovereign-cloud/seca"`
+
+## Schema Types in Use
+
+| Terraform type | Framework type | Used for |
+|---|---|---|
+| String | `tfschema.StringAttribute` | names, IDs, timestamps, enums |
+| Int64 | `tfschema.Int64Attribute` | sizes (GB), counts (IOPS) |
+| Map(String) | `tfschema.MapAttribute{ElementType: types.StringType}` | labels, annotations, extensions |
+| List(String) | `tfschema.ListAttribute{ElementType: types.StringType}` | available_zones |
+| List(Object) | `tfschema.ListNestedAttribute` | providers list in region |
+| Number | `schema.NumberAttribute` | retry seconds in provider config |
+
+`Number` is used only in the provider schema for retry config because seconds need fractional support (`1.5` = 1500ms). Resource schemas use `Int64` for integer quantities.
+
+## Attribute Classification
+
+| Classification | When to use |
+|---|---|
+| `Required` | Must be specified by user; drives API calls |
+| `Computed` | Set by the API or derived from provider config |
+| `Optional + Computed` | User may set it; API may default or modify it |
+
+Current `Optional + Computed` attributes:
+- `seca_image.initializer` — user may set; API defaults if omitted
+- `seca_image.boot` — user may set; API defaults if omitted
+
+## Plan Modifiers
+
+Only `stringplanmodifier.RequiresReplace()` is used. It is applied to:
+- `name` on all resources (SECA names are immutable)
+- `workspace_id` on workspace-scoped resources
+
+No `UseStateForUnknown()` is currently used. This means computed fields show `(known after apply)` on every plan even when unchanged — a known gap.
+
+## Reading State vs Plan vs Config
+
+| Operation | Where to read input from |
+|---|---|
+| Create | `req.Plan.Get()` |
+| Read | `req.State.Get()` |
+| Update | `req.Plan.Get()` |
+| Delete | `req.State.Get()` |
+| Data source Read | `req.Config.Get()` |
+
+This pattern is consistent across all resources.
+
+## Null and Unknown Handling
+
+The framework distinguishes three states for any attribute value: set, null, unknown.
+
+For Optional fields that may not be sent to the API:
+```go
+if !data.SourceImageId.IsNull() && !data.SourceImageId.IsUnknown() {
+    block.Spec.SourceImageRef = &sdk.Reference{Resource: data.SourceImageId.ValueString()}
+}
+```
+
+For `fromRefPtr()` — an optional pointer-to-Reference returned by the API:
+```go
+func fromRefPtr(ref *sdk.Reference) types.String {
+    if ref == nil {
+        return types.StringNull()
+    }
+    return types.StringValue(ref.Resource)
+}
+```
+
+The `types_test.go` tests explicitly verify null/unknown/zero behavior for all helpers.
+
+## Diagnostics
+
+Use `resp.Diagnostics.Append(...)` to collect errors from sub-operations:
+```go
+data, diags := xxxToModel(ctx, sdkObj)
+resp.Diagnostics.Append(diags...)
+if resp.Diagnostics.HasError() {
+    return
+}
+```
+
+Check `HasError()` immediately after every `Append()` or `Get()` call. Do not continue processing after an error is added.
+
+## Nested Objects (Lists of Objects)
+
+The region data source demonstrates the pattern for `ListNestedAttribute`:
+
+```go
+// Schema
+"providers": tfschema.ListNestedAttribute{
+    Computed: true,
+    NestedObject: tfschema.NestedAttributeObject{
+        Attributes: map[string]tfschema.Attribute{...},
+    },
+},
+
+// Model struct
+type RegionProviderModel struct {
+    Name    types.String `tfsdk:"name"`
+    ...
+}
+
+// Attr types map (required for ListValueFrom)
+var regionProviderAttrTypes = map[string]attr.Type{
+    "name":    types.StringType,
+    ...
+}
+
+// Mapping
+providers := make([]RegionProviderModel, 0, len(region.Spec.Providers))
+for _, p := range region.Spec.Providers {
+    providers = append(providers, RegionProviderModel{...})
+}
+providersList, d := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: regionProviderAttrTypes}, providers)
+```
+
+Always pre-declare the `AttrTypes` map as a package-level `var` for reuse in tests.
+
+## Features Not Yet Used
+
+The following framework features are available but not yet used in this provider. Do not introduce them without first discussing with the team and updating this document:
+
+| Feature | Reason not yet used |
+|---|---|
+| `ConfigValidators` | No cross-field validation needed yet |
+| `Validators` (field-level) | No format validation implemented |
+| `UseStateForUnknown()` | Known gap; all computed fields re-render on plan |
+| `ImportState` | Not implemented; see [known-issues.md](known-issues.md) |
+| `StateUpgraders` | No schema version changes yet |
+| `tflog` | No structured logging implemented |
+| Timeouts (`timeouts` block) | Not implemented; retry config is used instead |
+| `SemanticEquals` | Not implemented |
+| `Identity` | Not implemented |
+
+When implementing these, reference the official framework documentation and follow patterns from existing resources.

--- a/ai/testing-strategy.md
+++ b/ai/testing-strategy.md
@@ -1,0 +1,142 @@
+# Testing Strategy
+
+## Two-Layer Approach
+
+The provider uses two completely separate test layers, each with a different purpose and location.
+
+## Layer 1: Unit Tests (`internal/provider/`)
+
+**Package:** `package provider` (white-box access to unexported functions)
+
+**Purpose:** Verify that mapping functions between SDK types and Terraform model types work correctly — including all edge cases (null, zero, empty, missing optional fields).
+
+**Scope:** Only `types.go` helpers and the `xxxToXxxModel()` / `xxxFromModel()` private functions. No HTTP calls. No mocking framework.
+
+**Pattern:**
+```go
+func TestBlockStorageToResourceModel(t *testing.T) {
+    // Build an SDK object with known fields
+    block := &sdk.BlockStorage{
+        Metadata: &sdk.RegionalWorkspaceResourceMetadata{...},
+        Spec: sdk.BlockStorageSpec{...},
+    }
+
+    // Call the mapping function
+    model, diags := blockStorageToResourceModel(context.Background(), block)
+
+    // Assert no errors
+    require.False(t, diags.HasError())
+
+    // Assert every field
+    assert.Equal(t, "expected", model.Field.ValueString())
+    assert.True(t, model.NullableField.IsNull())
+}
+```
+
+**Test naming:** `Test<FunctionName>` e.g. `TestBlockStorageToResourceModel`, `TestFromTime`.
+
+**What to cover in unit tests:**
+- All standard metadata fields (id, name, tenant, region, created_at, deleted_at, last_modified_at)
+- All labels/annotations/extensions (non-nil and nil/empty)
+- All spec fields (required and optional)
+- Optional pointer fields: nil → null, non-nil → value
+- Status fields (data sources only): each possible state value
+- Edge cases: zero time, nil pointer, empty map, null map
+
+**What NOT to cover in unit tests:** API calls, provider lifecycle, Terraform plan/apply — that's Layer 2.
+
+## Layer 2: Acceptance Tests (`internal/acctest/`)
+
+**Package:** `package acctest` (separate package, no white-box access)
+
+**Purpose:** Verify end-to-end behavior against a live SECA cluster. Tests create real resources, verify their state via Terraform, and destroy them on teardown.
+
+**Guard:** Tests only run when `TF_ACC=1` is set. The CI job sets this. Local runs require a live cluster.
+
+**Cluster:** Tests use the provider config in `provider_test.go`, which hardcodes endpoints at `172.18.0.2:30081`. Acceptance tests cannot currently be run against an arbitrary cluster without editing this file.
+
+**Pattern:**
+```go
+func TestAccBlockStorage(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccBlockStorageResourceConfig(),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttr("seca_block_storage.test", "name", "block-storage-1"),
+                    ...
+                ),
+            },
+            {
+                Config: testAccBlockStorageDataSourceConfig(),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttr("data.seca_block_storage.test", "state", "active"),
+                    ...
+                ),
+            },
+        },
+    })
+}
+```
+
+**Config builder convention:** Private functions named `testAcc<Resource><Type>Config()` where type is `ResourceConfig`, `DataSourceConfig`, or `UpdateConfig`.
+
+**What each acceptance test must cover:**
+
+| Step | What to verify |
+|---|---|
+| Step 1: Create resource | All user-specified fields are set correctly |
+| Step 2: Create + data source | Data source reads resource state; `state` = "active" |
+| Step 3 (if updatable fields exist): Update | Updated fields are reflected |
+
+**Missing acceptance test coverage (gaps):**
+- No update step tests — no resource currently has a multi-step test with an update
+- No import state tests (`ImportStateVerify: true`)
+- No destroy verification (`CheckDestroy`)
+- No tests for invalid configurations (expect planning errors)
+
+## Running Tests
+
+```bash
+# Unit tests only (no TF_ACC needed)
+go test -v -cover -timeout=120s -parallel=10 ./...
+
+# Single unit test
+go test -v -run TestBlockStorageToResourceModel ./internal/provider/
+
+# Acceptance tests (requires TF_ACC=1 and live cluster)
+TF_ACC=1 go test -v -cover -timeout 120m ./...
+
+# Single acceptance test
+TF_ACC=1 go test -v -run TestAccBlockStorage ./internal/acctest/
+```
+
+## Mocking Strategy
+
+**There is no mocking.** Unit tests test pure mapping functions that have no external dependencies. Acceptance tests hit a real cluster. This is intentional:
+
+- Mocking the SDK would couple tests to internal SDK implementation details
+- The only logic worth unit-testing is the `model ↔ SDK` mapping — and that has no side effects
+
+Do not introduce mocking frameworks (mockery, gomock, testify/mock) for this layer.
+
+## Test Dependencies
+
+- `github.com/stretchr/testify` — `assert` and `require`
+- `github.com/hashicorp/terraform-plugin-testing` — acceptance test helpers
+
+Do not use `terraform-plugin-sdk/v2/helper/acctest` or `terraform-plugin-sdk/v2/helper/resource` — depguard blocks them.
+
+## What to Test When Implementing a New Resource
+
+**Unit tests to write:**
+1. `TestXxxToResourceModel` — covers the SDK→resource model mapping with a fully populated SDK object and all nullable/optional fields
+2. `TestXxxToDataSourceModel` — same but for the data source model, with Status fields
+3. (If `xxxFromModel` has conditional logic) — test each conditional branch
+
+**Acceptance tests to write:**
+1. `TestAccXxx` with at least:
+   - Step 1: Create with all required fields; check all output attributes
+   - Step 2: Add data source; verify it reads the created resource correctly


### PR DESCRIPTION
## Summary

- Introduces an `ai/` directory with 14 reference documents and 5 reusable AI prompts, making the repository self-describing for AI agents and human contributors
- Adds `CLAUDE.md` for Claude Code with commands, architecture summary, and a pointer to the scaffold
- Every document is grounded in the current implementation — no generic advice

## Documents Added

| File | Purpose |
|---|---|
| `ai/requirements.md` | Version matrix, provider goals, compatibility policy |
| `ai/architecture.md` | Two-client model, scoping, resource lifecycle, error flow |
| `ai/async-operations.md` | Mandatory Create/Update polling pattern |
| `ai/provider-conventions.md` | Naming, schema patterns, Configure() rules |
| `ai/terraform-framework.md` | Framework usage specific to this provider |
| `ai/coding-guidelines.md` | Imports, mapping functions, error messages |
| `ai/testing-strategy.md` | Unit vs acceptance tests, no-mock rationale |
| `ai/guardrails.md` | Hard rules by category (Schema, Async, Errors, State, Tests) |
| `ai/review-checklist.md` | 50+ items for PR reviews |
| `ai/implementation-checklist.md` | Ordered steps for new resources/data sources |
| `ai/known-issues.md` | 12 identified gaps |
| `ai/roadmap.md` | Planned resources derived from `examples/use-cases/usage.tf` |
| `ai/glossary.md` | Domain terms and SDK type mapping |
| `ai/prompts/` | 5 ready-to-use prompts: implementation, review, bugfix, refactor, feature |

## Notable findings documented in known-issues.md

- No `ImportState` on any resource
- No 404 handling in `Read()` — out-of-band deletions cause errors instead of removing from state
- `Delete()` does not poll for completion — may race on same-named recreate
- Copy-paste bug: `resource_workspace.go` Create() error says "Error updating workspace" instead of "Error creating workspace"
- No `UseStateForUnknown()` — all computed fields show `(known after apply)` unnecessarily on every plan

## Test plan

- [ ] Review each document for accuracy against the current codebase
- [ ] Verify the implementation-checklist covers all steps needed to implement the next planned resource
- [ ] Optionally: use one of the `ai/prompts/` prompts in a real AI session and confirm it produces correct output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
