### PR TITLE
Add AI development scaffold and fix ReferenceURN documentation

### DIFF
--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -91,15 +91,29 @@ The mapping between Terraform models and SDK types is done exclusively by the pr
 
 ## Reference System
 
-The SECA API uses a `<kind>/<name>` format for resource references:
+The SECA API uses structured references to identify resources. A reference is an object with the following fields:
 
-- `regions/region-1`
-- `workspaces/workspace-1`
-- `block-storages/my-vol`
-- `images/my-image`
-- `storage-skus/RD500`
+| Field | Required | Description | Example |
+|---|---|---|---|
+| `region` | no | Region; inferred from context if omitted | `eu-central-1` |
+| `provider` | no | Provider+version; inferred if omitted | `seca.compute/v1` |
+| `tenant` | no | Tenant; inferred if omitted | `tenant-1` |
+| `workspace` | no | Workspace; inferred if omitted | `workspace-1` |
+| `resource` | **yes** | Resource path within its workspace context | `instances/my-server` |
 
-These full references are stored as Terraform `id` (mapped from `Metadata.Ref`). When resources reference each other (e.g., `block_storage_id` on an image), they store the full reference string.
+The `resource` path is `<type>/<name>` for flat resources, or `<parent-type>/<parent-name>/<child-type>/<child-name>` for hierarchical resources.
+
+`Metadata.Ref` (stored as Terraform `id`) is the **full serialized URN** following the pattern `{provider}/{version}/tenants/{tenant}/workspaces/{workspace}/{type}/{name}`. For tenant-scoped resources the workspace segment is absent; for global resources the tenant segment is absent too. Examples by scope:
+
+| Scope | Resource | Example `id` |
+|---|---|---|
+| Global | `seca_region` | `seca.region/v1/regions/region-1` |
+| Tenant | `seca_workspace` | `seca.workspace/v1/tenants/tenant-1/workspaces/workspace-1` |
+| Tenant | `seca_image` | `seca.storage/v1/tenants/tenant-1/images/image-1` |
+| Tenant | `seca_storage_sku` | `seca.storage/v1/tenants/tenant-1/storage-skus/RD500` |
+| Workspace | `seca_block_storage` | `seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/my-vol` |
+
+**Cross-resource reference fields** (e.g., `block_storage_id` on an image, `sku_id` on a block storage) store only the `resource` path segment from the structured `sdk.Reference` object — not the full URN. The provider, tenant, and workspace are left blank in the `Reference` struct and inferred by the API from context.
 
 ## Scoping Model
 

--- a/ai/known-issues.md
+++ b/ai/known-issues.md
@@ -2,9 +2,11 @@
 
 This document captures observed technical debt and known issues. **Do not fix these without a tracked issue and review.** The purpose of documenting them here is to ensure AI agents do not accidentally work around or worsen these problems.
 
+Epic tracker: [#16 — Technical Debt Plan](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/16)
+
 ## Critical Gaps
 
-### 1. No `ImportState` Implementation
+### 1. No `ImportState` Implementation — [#5](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/5)
 
 **Impact:** Users cannot import existing SECA resources into Terraform state (`terraform import`).
 
@@ -16,7 +18,7 @@ This document captures observed technical debt and known issues. **Do not fix th
 
 ---
 
-### 2. No 404 Handling in `Read()`
+### 2. No 404 Handling in `Read()` — [#6](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/6)
 
 **Impact:** If a resource is deleted out-of-band (outside Terraform), `Read()` will return an error diagnostic instead of removing the resource from state. Terraform will keep trying to refresh a non-existent resource.
 
@@ -28,7 +30,7 @@ This document captures observed technical debt and known issues. **Do not fix th
 
 ---
 
-### 3. Delete Does Not Poll for Completion
+### 3. Delete Does Not Poll for Completion — [#7](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/7)
 
 **Impact:** Terraform considers a resource deleted as soon as `DeleteXxx()` returns without error, but the resource may still be deleting on the API side. A subsequent create of a same-named resource may conflict.
 
@@ -38,7 +40,7 @@ This document captures observed technical debt and known issues. **Do not fix th
 
 ---
 
-### 4. Copy-Paste Error in `resource_workspace.go` Create()
+### 4. Copy-Paste Error in `resource_workspace.go` Create() — [#8](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/8)
 
 **Location:** `internal/provider/resource_workspace.go:168`
 
@@ -56,7 +58,7 @@ resp.Diagnostics.AddError(
 
 ## Design Gaps
 
-### 5. Duplicated Mapping Logic Between Resource and Data Source
+### 5. Duplicated Mapping Logic Between Resource and Data Source — [#9](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/9)
 
 **Impact:** Every resource has both `xxxToResourceModel` and `xxxToDataSourceModel` with nearly identical code. The only difference is that data source models include `state` from status and use `Computed` for maps.
 
@@ -66,7 +68,7 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 6. No `UseStateForUnknown()` on Computed Fields
+### 6. No `UseStateForUnknown()` on Computed Fields — [#10](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/10)
 
 **Impact:** On every plan, all Computed fields (`tenant`, `region`, `created_at`, etc.) show as `(known after apply)` even when no change is expected. This produces noisy plans and erodes user trust.
 
@@ -74,7 +76,7 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 7. Retry Config Is Coarse-Grained
+### 7. Retry Config Is Coarse-Grained — [#11](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/11)
 
 **Impact:** All resources in a provider instance share the same retry config. A slow-provisioning instance and a fast-provisioning workspace cannot have different polling configs.
 
@@ -84,7 +86,7 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 8. No Structured Logging (`tflog`)
+### 8. No Structured Logging (`tflog`) — [#12](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/12)
 
 **Impact:** No debug output when `TF_LOG=DEBUG` is set. Debugging API interactions requires network tracing.
 
@@ -92,17 +94,7 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 9. `StorageSkuDataSource` Missing `created_at` / `deleted_at` / `last_modified_at`
-
-**Location:** `internal/provider/datasource_storage_sku.go`
-
-**Problem:** The `StorageSku` SDK type uses `SkuResourceMetadata` which may not have the same timestamp fields as `RegionalResourceMetadata`. The schema omits these fields entirely. This is inconsistent with other data sources.
-
-**Risk:** If `SkuResourceMetadata` gains timestamps, the schema is not ready to expose them.
-
----
-
-### 10. Acceptance Test Cluster Is Hard-Coded
+### 9. Acceptance Test Cluster Is Hard-Coded — [#13](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/13)
 
 **Location:** `internal/acctest/provider_test.go`
 
@@ -112,7 +104,7 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 11. No Update Acceptance Test Steps
+### 10. No Update Acceptance Test Steps — [#14](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/14)
 
 **Impact:** No acceptance test verifies that updating a resource's mutable fields (e.g., `size_gb` on block storage, `labels`) is reflected correctly.
 
@@ -120,6 +112,6 @@ resp.Diagnostics.AddError(
 
 ---
 
-### 12. No `CheckDestroy` in Acceptance Tests
+### 11. No `CheckDestroy` in Acceptance Tests — [#15](https://github.com/eu-sovereign-cloud/terraform-provider-seca/issues/15)
 
 **Impact:** Acceptance tests do not verify that resources are actually deleted from the API after `terraform destroy`. The framework's automatic cleanup may succeed at the provider level while leaving orphaned resources on the API.

--- a/internal/provider/datasource_block_storage_test.go
+++ b/internal/provider/datasource_block_storage_test.go
@@ -22,7 +22,7 @@ func TestBlockStorageToDataSourceModel(t *testing.T) {
 			Workspace:      "workspace-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "block-storages/block-storage-1",
+			Ref:            "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/block-storage-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -40,7 +40,7 @@ func TestBlockStorageToDataSourceModel(t *testing.T) {
 	model, diags := blockStorageToDataSourceModel(context.Background(), block)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "block-storages/block-storage-1", model.Id.ValueString())
+	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/block-storage-1", model.Id.ValueString())
 	assert.Equal(t, "block-storage-1", model.Name.ValueString())
 	assert.Equal(t, "workspace-1", model.WorkspaceId.ValueString())
 

--- a/internal/provider/datasource_image_test.go
+++ b/internal/provider/datasource_image_test.go
@@ -21,7 +21,7 @@ func TestImageToDataSourceModel(t *testing.T) {
 			Name:           "image-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "images/image-1",
+			Ref:            "seca.storage/v1/tenants/tenant-1/images/image-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -41,7 +41,7 @@ func TestImageToDataSourceModel(t *testing.T) {
 	model, diags := imageToDataSourceModel(context.Background(), image)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "images/image-1", model.Id.ValueString())
+	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/images/image-1", model.Id.ValueString())
 	assert.Equal(t, "image-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())

--- a/internal/provider/datasource_region_test.go
+++ b/internal/provider/datasource_region_test.go
@@ -19,7 +19,7 @@ func TestRegionToDataSourceModel(t *testing.T) {
 	region := &sdk.Region{
 		Metadata: &sdk.GlobalResourceMetadata{
 			Name:           "region-1",
-			Ref:            "regions/region-1",
+			Ref:            "seca.region/v1/regions/region-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -36,7 +36,7 @@ func TestRegionToDataSourceModel(t *testing.T) {
 	model, diags := regionToDataSourceModel(context.Background(), region)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "regions/region-1", model.Id.ValueString())
+	assert.Equal(t, "seca.region/v1/regions/region-1", model.Id.ValueString())
 	assert.Equal(t, "region-1", model.Name.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())

--- a/internal/provider/datasource_storage_sku_test.go
+++ b/internal/provider/datasource_storage_sku_test.go
@@ -16,7 +16,7 @@ func TestStorageSkuToDataSourceModel(t *testing.T) {
 			Name:   "sku-1",
 			Tenant: "tenant-1",
 			Region: "region-1",
-			Ref:    "storage-skus/sku-1",
+			Ref:    "seca.storage/v1/tenants/tenant-1/storage-skus/sku-1",
 		},
 		Labels:      sdk.Labels{"tier": "gold"},
 		Annotations: sdk.Annotations{"team": "core"},
@@ -31,7 +31,7 @@ func TestStorageSkuToDataSourceModel(t *testing.T) {
 	model, diags := storageSkuToDataSourceModel(context.Background(), sku)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "storage-skus/sku-1", model.Id.ValueString())
+	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/storage-skus/sku-1", model.Id.ValueString())
 	assert.Equal(t, "sku-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())

--- a/internal/provider/datasource_workspace_test.go
+++ b/internal/provider/datasource_workspace_test.go
@@ -21,7 +21,7 @@ func TestWorkspaceToDataSourceModel(t *testing.T) {
 			Name:           "workspace-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "workspaces/ws-1",
+			Ref:            "seca.workspace/v1/tenants/tenant-1/workspaces/ws-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -35,7 +35,7 @@ func TestWorkspaceToDataSourceModel(t *testing.T) {
 	model, diags := workspaceToDataSourceModel(context.Background(), workspace)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "workspaces/ws-1", model.Id.ValueString())
+	assert.Equal(t, "seca.workspace/v1/tenants/tenant-1/workspaces/ws-1", model.Id.ValueString())
 	assert.Equal(t, "workspace-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())

--- a/internal/provider/resource_block_storage_test.go
+++ b/internal/provider/resource_block_storage_test.go
@@ -22,7 +22,7 @@ func TestBlockStorageToResourceModel(t *testing.T) {
 			Workspace:      "workspace-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "block-storages/block-storage-1",
+			Ref:            "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/block-storage-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -40,7 +40,7 @@ func TestBlockStorageToResourceModel(t *testing.T) {
 	model, diags := blockStorageToResourceModel(context.Background(), block)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "block-storages/block-storage-1", model.Id.ValueString())
+	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/block-storage-1", model.Id.ValueString())
 	assert.Equal(t, "block-storage-1", model.Name.ValueString())
 	assert.Equal(t, "workspace-1", model.WorkspaceId.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())

--- a/internal/provider/resource_image_test.go
+++ b/internal/provider/resource_image_test.go
@@ -21,7 +21,7 @@ func TestImageToResourceModel(t *testing.T) {
 			Name:           "image-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "images/image-1",
+			Ref:            "seca.storage/v1/tenants/tenant-1/images/image-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -40,7 +40,7 @@ func TestImageToResourceModel(t *testing.T) {
 	model, diags := imageToResourceModel(context.Background(), image)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "images/image-1", model.Id.ValueString())
+	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/images/image-1", model.Id.ValueString())
 	assert.Equal(t, "image-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())

--- a/internal/provider/resource_workspace_test.go
+++ b/internal/provider/resource_workspace_test.go
@@ -21,7 +21,7 @@ func TestWorkspaceToResourceModel(t *testing.T) {
 			Name:           "workspace-1",
 			Tenant:         "tenant-1",
 			Region:         "region-1",
-			Ref:            "workspaces/workspace-1",
+			Ref:            "seca.workspace/v1/tenants/tenant-1/workspaces/workspace-1",
 			CreatedAt:      createdAt,
 			DeletedAt:      &deletedAt,
 			LastModifiedAt: modifiedAt,
@@ -34,7 +34,7 @@ func TestWorkspaceToResourceModel(t *testing.T) {
 	model, diags := workspaceToResourceModel(context.Background(), workspace)
 	require.False(t, diags.HasError())
 
-	assert.Equal(t, "workspaces/workspace-1", model.Id.ValueString())
+	assert.Equal(t, "seca.workspace/v1/tenants/tenant-1/workspaces/workspace-1", model.Id.ValueString())
 	assert.Equal(t, "workspace-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())


### PR DESCRIPTION
## Summary

- Adds a comprehensive `ai/` scaffold with architecture docs, guardrails, implementation checklists, prompts, and known-issues tracking to guide AI-assisted development on this provider
- Adds `CLAUDE.md` project instructions for Claude Code
- Corrects the `ReferenceURN` format in `ai/architecture.md` (full URN including provider/tenant/workspace, not just `<type>/<name>`)
- Removes a false known-issue entry for `StorageSkuDataSource` timestamps (`SkuResourceMetadata` intentionally omits them)
- Links all 11 known issues to their GitHub tracking issues (#5–#15), with epic #16
- Updates all unit test `Metadata.Ref` fixtures to use realistic full URNs

## Test plan

- [x] All unit tests pass (`go test ./internal/provider/...`)
- [x] No functional provider code changed — docs and test fixtures only

🤖 Generated with [Claude Code](https://claude.com/claude-code)