### PR TITLE
GA-10: Add resource_provider computed attribute to all resources and data sources

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -22,6 +22,7 @@ These documents onboard AI agents (and human contributors) to work safely, consi
 | [implementation-checklist.md](implementation-checklist.md) | Checklist for implementing new resources/data sources |
 | [known-issues.md](known-issues.md) | Technical debt — do not accidentally work around these |
 | [roadmap.md](roadmap.md) | Planned resources and their priority |
+| [gap-analysis.md](gap-analysis.md) | Full gap analysis, issue drafts, and phased implementation roadmap |
 | [glossary.md](glossary.md) | Domain terminology and SDK type mapping |
 
 ## Prompts
@@ -43,4 +44,6 @@ Ready-to-use prompts for common AI tasks:
 3. [async-operations.md](async-operations.md) — understand the most critical pattern
 4. [provider-conventions.md](provider-conventions.md) — understand naming and schema rules
 5. [guardrails.md](guardrails.md) — understand what never to do
-6. [implementation-checklist.md](implementation-checklist.md) — before writing any new resource
+6. [roadmap.md](roadmap.md) — understand planned scope
+7. [gap-analysis.md](gap-analysis.md) — full gap analysis, issue drafts, phased roadmap
+8. [implementation-checklist.md](implementation-checklist.md) — before writing any new resource

--- a/ai/gap-analysis.md
+++ b/ai/gap-analysis.md
@@ -1,0 +1,527 @@
+# Gap Analysis & Implementation Roadmap
+
+> **Status:** July 2026. Grounded against `go-sdk@v0.4.2`, `examples/`, `ai/`, and the live provider source.
+>
+> **Scope:** Foundation + Authorization (compute, networking, storage, IAM). Beta SDK extensions
+> (loadbalancer, natgateway, kubernetes, objectstorage) are deferred — see Appendix A.
+>
+> **GitHub issues:** drafts in §11. Reconcile against existing issues #5–#15 (epic #16) before filing.
+
+---
+
+## 1. Executive Summary
+
+**Overall maturity: early foundation / ~25% of intended scope.**
+
+The provider has a clean, consistent architecture and a well-documented AI scaffold (`ai/`), but exposes only 3 of ~13 planned resources and 5 of ~15 planned data sources. Every implemented resource carries the same set of production-blocking cross-cutting gaps.
+
+**Completion estimate (foundation + auth scope):**
+
+| Dimension | Done | Total | % |
+|---|---|---|---|
+| Resources | 3 | 13 | 23% |
+| Data sources | 5 | 15 | 33% |
+| Cross-cutting production-readiness (import, drift, delete-polling, logging, timeouts) | — | — | ~10% |
+
+**Architecture quality: good.** One flat `internal/provider` package, strict naming/schema conventions (`ai/provider-conventions.md`), a correct `GlobalClient → RegionalClient` bootstrap, and a documented async-polling pattern. The design scales to the remaining resources with no structural change required.
+
+**Major risks:**
+
+1. **Production-readiness gaps are systemic, not per-resource** — shipping more resources without first fixing import/drift/delete-polling multiplies the debt. *Fix cross-cutting concerns first.*
+2. **No drift detection** — `Read` errors instead of removing out-of-band-deleted resources, making the provider unsafe for real state management.
+3. **Delete does not confirm completion** → recreate races. The SDK's `WatchXxxUntilDeleted` observers are available but unused.
+4. **Hard-coded acceptance-test cluster** (`172.18.0.2:30081`) blocks CI; regressions in new resources will not be caught.
+5. **Mapper duplication** (resource vs data-source) will be replicated 10× as new resources land unless refactored early.
+
+**Bottom line:** the hard architectural problems are solved; the remaining work is high-volume but low-novelty wiring, plus a focused hardening pass. The recommended sequence puts hardening (Phase 1) before breadth (Phases 2–5).
+
+---
+
+## 2. Missing Features (grouped by service)
+
+### Cross-cutting (all existing resources)
+
+- `ImportState` (#5) — no `resource.ResourceWithImportState` implementation anywhere.
+- 404 → `RemoveResource` drift handling in `Read` (#6) — out-of-band deletes permanently break plans.
+- Delete polling via `WatchXxxUntilDeleted` (#7) — the SDK observer exists; the provider ignores it.
+- `UseStateForUnknown` on stable computed fields (#10) — every plan shows `(known after apply)` noise.
+- `tflog` structured logging (#12) — `TF_LOG=DEBUG` produces no provider output.
+- Per-resource `timeouts` blocks (#11) — all resources share one coarse provider-level retry config.
+- Shared mapper refactor (#9) — resource/data-source mappers duplicate ~80% of mapping code.
+- Env-driven acctest endpoints (#13) — cluster URL is hard-coded in source.
+- Update, `ImportStateVerify`, and `CheckDestroy` acctest steps (#14, #15).
+
+### Compute (`ComputeV1`)
+
+- `seca_instance` resource (CRUD + power lifecycle: Start/Stop/Restart + `GetInstanceUntilPowerState`).
+- `seca_instance` data source.
+- `seca_instance_sku` data source.
+
+### Networking (`NetworkV1`)
+
+- Resources: `seca_network`, `seca_subnet`, `seca_route_table`, `seca_internet_gateway`, `seca_security_group` (with nested inline rules), `seca_public_ip`, `seca_nic`.
+- Data sources for each of the above, plus `seca_network_sku`.
+
+### Authorization (`AuthorizationV1`, `GlobalClient`)
+
+- `seca_role` resource + data source.
+- `seca_role_assignment` resource + data source.
+- Uses `GlobalClient.AuthorizationV1` — mirrors the `seca_region` data source's GlobalClient usage.
+
+### Reconciliation required
+
+- `examples/resources/*/resource.tf` files reference a computed `resource_provider` attribute (provider name + version from `Metadata.Ref`) that none of the 3 current resources expose. This must be resolved before mass doc generation to avoid `docs/` drift.
+
+---
+
+## 3. Missing Resources
+
+| Resource | SDK backing (verified `secapi/*.go`) | Scope | Key spec attributes | Priority |
+|---|---|---|---|---|
+| `seca_network` | `NetworkV1.CreateOrUpdateNetwork` | Workspace | `sku_id`, `cidr.ipv4`, computed `additional_cidrs` | P1 |
+| `seca_internet_gateway` | `NetworkV1.CreateOrUpdateInternetGateway` | Workspace | computed `egress_only` | P1 |
+| `seca_route_table` | `NetworkV1.CreateOrUpdateRouteTable` | Workspace | `network_id`, `routes[]{destination_cidr_block, target_id}` | P1 |
+| `seca_subnet` | `NetworkV1.CreateOrUpdateSubnet` | Workspace | `network_id`, `cidr.ipv4`, `route_table_id`, computed `zone`, `sku_id` | P1 |
+| `seca_security_group` | `NetworkV1.CreateOrUpdateSecurityGroup` + `…Rule` | Workspace | `rules[]{direction, protocol, ports{list\|from\|to}, source_refs}`, computed `rule_refs` | P2 |
+| `seca_public_ip` | `NetworkV1.CreateOrUpdatePublicIp` | Workspace | `version` (IPv4/IPv6), computed `address`, `attached_to` | P2 |
+| `seca_nic` | `NetworkV1.CreateOrUpdateNic` | Workspace | `subnet_id`, `addresses[]`, `public_ip_id(s)`, computed `mac_address`, `security_group_ids` | P2 |
+| `seca_instance` | `ComputeV1.CreateOrUpdateInstance` + Start/Stop/Restart | Workspace | `sku_id`, `primary_nic_id`, `zone`, `ssh_keys[]`, `boot_volume{device_id}`, `data_volumes`, computed `power_state`, `power_state_since` | P3 |
+| `seca_role` | `AuthorizationV1.CreateOrUpdateRole` | Tenant (Global) | `permissions[]{provider, resources[], verb[]}` | P4 |
+| `seca_role_assignment` | `AuthorizationV1.CreateOrUpdateRoleAssignment` | Tenant (Global) | `subs[]`, `scopes[]{tenants, regions, workspaces}`, `roles[]` | P4 |
+
+**Note on `security_group_rule`:** The SDK exposes `CreateOrUpdateSecurityGroupRule` as a distinct sub-resource, but `examples/` models rules **inline** inside `seca_security_group`. Recommendation: keep rules inline (matching examples), with rule CRUD managed inside the security-group resource's Create/Update. Do not add a separate `seca_security_group_rule` resource unless the API semantics require independent lifecycle.
+
+---
+
+## 4. Missing Data Sources
+
+| Data source | SDK backing | Priority |
+|---|---|---|
+| `seca_network_sku` | `NetworkV1.ListSkus` / `GetSku` | P1 |
+| `seca_network` | `NetworkV1.GetNetwork` | P1 |
+| `seca_internet_gateway` | `NetworkV1.GetInternetGateway` | P1 |
+| `seca_route_table` | `NetworkV1.GetRouteTable` | P1 |
+| `seca_subnet` | `NetworkV1.GetSubnet` | P1 |
+| `seca_security_group` | `NetworkV1.GetSecurityGroup` | P2 |
+| `seca_public_ip` | `NetworkV1.GetPublicIp` | P2 |
+| `seca_nic` | `NetworkV1.GetNic` | P2 |
+| `seca_instance` | `ComputeV1.GetInstance` | P3 |
+| `seca_instance_sku` | `ComputeV1.ListSkus` / `GetSku` | P3 |
+| `seca_role` | `AuthorizationV1.GetRole` | P4 |
+| `seca_role_assignment` | `AuthorizationV1.GetRoleAssignment` | P4 |
+
+---
+
+## 5. Missing Acceptance Tests
+
+| Area | Gap | Tracking |
+|---|---|---|
+| All existing resources | No Update step (mutate mutable fields, e.g. `size_gb`, `labels`) | #14 |
+| All existing resources | No `CheckDestroy` verifying API-side deletion | #15 |
+| All existing resources | No `ImportState` / `ImportStateVerify` step | blocked by #5 |
+| Acctest harness | Endpoints hard-coded to `172.18.0.2:30081`; cannot run in CI | #13 |
+| All new resources | Full CRUD + import + update + `CheckDestroy` per resource | GA-20, GA-27, GA-32, GA-37 |
+| `seca_instance` | Power-state lifecycle (start / stop / restart) | GA-32 |
+| Negative cases | Invalid SKU / invalid CIDR / missing workspace — assert error messages | GA-41 |
+
+---
+
+## 6. Missing Unit Tests
+
+| Area | Gap |
+|---|---|
+| Existing mappers | Only happy-path `xxxToResourceModel`; no null/unknown-field, empty-map, nil-pointer-ref cases |
+| 404 handling | No test that `Read` calls `RemoveResource` on not-found (blocked by GA-1/#6) |
+| Provider `Configure` | No test for retry-default fallback, nil `authorization_v1`, wrong provider-data type |
+| `types.go` helpers | `numberToDuration` / `numberToInt` edge cases partially covered (`types_test.go`); add fractional, zero, null |
+| New resources | `fooFromModel` / `fooToModel` round-trip tests, nested-object mapping (routes, rules, scopes) |
+| Schema validators | Once CIDR / enum / port-range validators are added, unit-test each |
+
+---
+
+## 7. Documentation Gaps
+
+| Gap | Detail |
+|---|---|
+| Registry docs for 10 resources / 12 data sources | `docs/` only covers workspace, image, block_storage (+ 5 data sources). `make generate` must run after every new resource. |
+| No import guide | No `terraform import` examples; add `docs/guides/import.md` once GA-3 / #5 lands. |
+| No authentication guide | Token acquisition, `global_providers` endpoints, tenant/region selection are undocumented as a user-facing guide. |
+| No troubleshooting guide | Async timeout tuning (`retry`), eventual-consistency behavior, common API errors. |
+| `examples/` ↔ schema drift | `resource_provider` output in examples has no schema backing; regenerate examples per resource (GA-10). |
+| Provider index thin | `docs/index.md` should document the `retry` block, non-goals (single-region per block), and the `id` reference format. |
+
+---
+
+## 8. Technical Debt
+
+### Critical
+
+| ID | Description | Fix |
+|---|---|---|
+| TD-C1 (#6) | **No 404 handling in `Read`.** Out-of-band deletes cause permanent plan errors. | Detect not-found via `secapi/errors.go`; call `resp.State.RemoveResource(ctx)` and return. |
+| TD-C2 (#7) | **Delete does not confirm completion.** Recreate races possible. | After `DeleteXxx`, call `WatchXxxUntilDeleted` with `ResourceObserverConfig`. Note: no `Deleted` state exists — deletion is confirmed by the Watch observer (404), not a state poll. |
+| TD-C3 (#5) | **No `ImportState`.** Users cannot `terraform import` existing resources. | Implement `resource.ResourceWithImportState`; passthrough on `id` once confirmed `GetXxx` accepts a parsed `<kind>/<name>` ref. |
+
+### High
+
+| ID | Description | Fix |
+|---|---|---|
+| TD-H1 (#8) | Copy-paste error: `resource_workspace.go:168` says `"Error updating workspace"` in `Create()`. | One-line string fix. |
+| TD-H2 (#13) | Hard-coded acctest cluster (`172.18.0.2:30081`) blocks CI. | Read from `SECA_REGION_ENDPOINT`, `SECA_AUTH_ENDPOINT` env vars. |
+| TD-H3 | `examples/` reference `resource_provider` attribute with no schema backing. | Decide add-vs-remove; apply uniformly before doc generation (GA-10). |
+| TD-H4 (#9) | Mapper duplication (~80% shared code between resource and data-source mappers). | Extract shared metadata/labels/timestamps helper; will be replicated 10× if not refactored before breadth work. |
+
+### Medium
+
+| ID | Description |
+|---|---|
+| TD-M1 (#10) | No `UseStateForUnknown` on stable computed fields → noisy plans on every apply. |
+| TD-M2 (#12) | No `tflog` structured logging → `TF_LOG=DEBUG` produces no provider-level output. |
+| TD-M3 (#11) | Provider-level retry only; no per-resource `timeouts` blocks (instances provision far slower than workspaces). |
+| TD-M4 | No schema validators (CIDR, IP-version enum, port range 1–65535). |
+| TD-M5 (#14/#15) | Acceptance tests lack Update steps and `CheckDestroy`. |
+
+### Low
+
+| ID | Description |
+|---|---|
+| TD-L1 | Inconsistent receiver names (`resource` vs `r`) across resource files. |
+| TD-L2 | Error detail strings built by hand per method — candidate for a small `diagError` helper. |
+| TD-L3 | `Configure` error message says `"Expected sdk.Clients"` but the actual type name is `clients`. |
+
+---
+
+## 9. Provider Improvement Suggestions
+
+> These are architectural recommendations. No code samples here — see `ai/implementation-checklist.md` for implementation patterns.
+
+1. **Shared metadata mapper.** Extract common metadata / labels / timestamps mapping into a helper reused by both resource and data-source mappers (addresses TD-H4 / #9). Apply the `datasource_region.go:143–172` nested-object pattern (`attr-type map` + `types.ListValueFrom`) for all list-of-objects fields (`routes`, `rules`, `scopes`, `permissions`).
+
+2. **Async lifecycle "kit".** A thin internal helper for the repeated async lifecycle — submit mutation → `GetXxxUntilState` → map → set state; delete → `WatchXxxUntilDeleted` — so each new resource's CRUD body becomes mapping-only. The SDK already provides the observers.
+
+3. **Framework `timeouts` blocks.** Adopt `timeouts.New()` per resource (create / update / delete) mapped onto the observer config, replacing/augmenting the coarse provider-level retry (TD-M3 / #11). Instances will need 5–10× longer timeouts than workspaces.
+
+4. **Centralize not-found detection.** One `isNotFound(err) bool` helper over `secapi/errors.go`, shared by every `Read` and by the delete-watch path (TD-C1 / #6).
+
+5. **Reusable validators.** CIDR-block, IP-version enum (`IPv4`/`IPv6`), port-range (1–65535), direction enum (`ingress`/`egress`). Document them in `ai/provider-conventions.md` so every networking resource applies them uniformly.
+
+6. **`tflog` convention.** Standard debug lines in `Configure`, `Create`, `Read`, `Update`, `Delete` (request ref, poll attempt count, final state). Cheap, high debugging payoff (TD-M2 / #12).
+
+7. **Reconcile `resource_provider`.** Surface the SDK's provider/version segment as a computed attribute on all resources *or* remove it from `examples/` — decide once in GA-10 before `make generate` bakes drift into `docs/`.
+
+---
+
+## 10. Prioritized Roadmap
+
+### Phase 1 — Production hardening (cross-cutting)
+
+**Rationale:** Every new resource inherits these patterns. Fixing them first prevents 10× duplication of debt; codifying them as convention protects all subsequent work. Also unblocks CI (env-driven acctests).
+
+**Scope:** not-found helper + `Read` drift (#6), delete-watch (#7), `ImportState` (#5), workspace diagnostic copy-paste fix (#8), env-driven acctests (#13), Update + `CheckDestroy` + `ImportStateVerify` acctest steps (#14/#15), shared mapper refactor (#9), `UseStateForUnknown` (#10), `tflog` (#12), `resource_provider` reconciliation (GA-10).
+
+**Dependencies:** none (all SDK primitives exist). **Effort:** M–L. **Risk:** low-med (must confirm SDK not-found signal in `secapi/errors.go` and verify import ref parsing before GA-3).
+
+---
+
+### Phase 2 — Networking core
+
+**Resources + data sources:** `seca_network`, `seca_internet_gateway`, `seca_route_table`, `seca_subnet` + matching data sources + `seca_network_sku`.
+
+**Rationale:** Highest immediate user value; prerequisite for NICs and instances. Internal ordering: `network` must exist before `route_table` and `subnet`.
+
+**Key challenge:** `seca_route_table` has a nested `routes[]` list-of-objects — use the region data-source's `types.ListValueFrom` pattern. `seca_network` needs a `cidr` nested object (`ipv4` string). CIDR validators apply here first.
+
+**Dependencies:** Phase 1 conventions. **Effort:** L. **Risk:** medium.
+
+---
+
+### Phase 3 — Networking edge
+
+**Resources + data sources:** `seca_security_group` (inline rules), `seca_public_ip`, `seca_nic` + matching data sources.
+
+**Rationale:** Required substrate for compute instances (NIC + public IP + security group must exist before an instance can be created).
+
+**Key challenge:** `seca_security_group` rules have a polymorphic `ports` object (`list`, `from`, or `from+to`). This requires a nested `SingleNestedAttribute` or custom object type with careful null/unknown handling. Port-range validators apply here.
+
+**Dependencies:** Phase 2 (subnet for NIC). **Effort:** L. **Risk:** medium-high (SG rule polymorphism).
+
+---
+
+### Phase 4 — Compute
+
+**Resources + data sources:** `seca_instance` (+ power lifecycle), `seca_instance` data source, `seca_instance_sku` data source.
+
+**Rationale:** The capstone that ties storage + networking together and makes `examples/use-cases/usage.tf` fully applyable end-to-end.
+
+**Key challenge:** Instance power-state modeling. Options: (a) computed `power_state` only (read-only), or (b) desired-state attribute that triggers Start/Stop during Update. Document the decision in GA-29 before implementing. Boot-volume and data-volumes are nested objects requiring the established pattern.
+
+**Dependencies:** Phases 2–3 + existing storage resources. **Effort:** L. **Risk:** high (power lifecycle semantics, `GetInstanceUntilPowerState`).
+
+---
+
+### Phase 5 — Authorization / IAM
+
+**Resources + data sources:** `seca_role`, `seca_role_assignment` + data sources.
+
+**Rationale:** Independent of compute/network — can be parallelized with Phases 2–4 by a second contributor. Uses `GlobalClient.AuthorizationV1` (mirrors `datasource_region.go`).
+
+**Key challenge:** `seca_role.permissions` and `seca_role_assignment.scopes` are nested lists-of-objects. Use the established nested-mapping pattern. Note that authorization resources are **tenant-scoped via GlobalClient**, not workspace-scoped via RegionalClient.
+
+**Dependencies:** Phase 1 only. **Effort:** M. **Risk:** medium.
+
+---
+
+### Phase 6 — Docs & polish
+
+**Scope:** Regenerate all `docs/` (`make generate`), author import/authentication/troubleshooting guides, add reusable schema validators, write negative acceptance tests, implement per-resource `timeouts` blocks, GA checklist.
+
+**Dependencies:** all prior phases. **Effort:** M. **Risk:** low.
+
+---
+
+## 11. GitHub Issues (draft)
+
+> Existing issues #5–#15 and epic #16 cover Phase-1 cross-cutting items. The entries below **reference** those issues and add implementation detail, then list **new** issues for Phases 2–6.
+>
+> **Issue template fields (apply to every issue):** Title · Description · Background · Requirements · Implementation Notes · Acceptance Criteria · Testing Requirements · Documentation Requirements · Dependencies · Labels · Estimated Complexity · Suggested Milestone · Definition of Done.
+
+---
+
+### Phase 1 — Hardening (refines #5–#15)
+
+**GA-1 (→#6) — `Read` drift: not-found → `RemoveResource`**
+- Background: `GetXxx` returns an error when a resource is deleted out-of-band; `Read` converts it to a diagnostic, leaving state permanently broken.
+- Requirements: inspect `secapi/errors.go` to identify the not-found error type/code; add `isNotFound(err) bool` in `clients.go`; update `Read` on `seca_workspace`, `seca_image`, `seca_block_storage`.
+- Acceptance criteria: delete a resource via API; `terraform plan` proposes recreate (not error).
+- Labels: `tech-debt`, `critical` · Complexity: S · Milestone: M1
+
+**GA-2 (→#7) — Delete polling via `WatchXxxUntilDeleted`**
+- Background: `Delete` returns as soon as `DeleteXxx` API call succeeds; the resource may still be terminating. A same-named recreate may conflict.
+- Requirements: after `DeleteXxx`, call `WatchXxxUntilDeleted(ctx, ref, ResourceObserverConfig{...retry fields...})`; handle timeout error as diagnostic. Note: no `Deleted` `ResourceState` exists — deletion is confirmed by the Watch observer (404).
+- Acceptance criteria: rapid destroy+create of same-named resource succeeds without conflict.
+- Labels: `tech-debt`, `critical` · Complexity: S · Milestone: M1
+
+**GA-3 (→#5) — `ImportState` on all 3 existing resources**
+- Background: no `resource.ResourceWithImportState` implementation exists.
+- Requirements: confirm `GetXxx` can resolve a `<kind>/<name>` ref (e.g. `block-storages/my-vol`) by inspecting `secapi/references.go`; implement `ImportState` using `resource.ImportStatePassthroughID`; update `Read` to accept both name and full ref as identity.
+- Acceptance criteria: `terraform import seca_block_storage.x block-storages/my-vol` produces valid state.
+- Labels: `feature`, `critical` · Complexity: M · Milestone: M1
+
+**GA-4 (→#8) — Fix diagnostic message in `resource_workspace.go:168`**
+- Background: `Create()` emits `"Error updating workspace"` instead of `"Error creating workspace"`.
+- Labels: `bug`, `good-first-issue` · Complexity: XS · Milestone: M1
+
+**GA-5 (→#13) — Env-driven acctest endpoints**
+- Background: `internal/acctest/provider_test.go` hard-codes `172.18.0.2:30081`; CI cannot run against a different cluster.
+- Requirements: read `SECA_REGION_ENDPOINT`, `SECA_AUTH_ENDPOINT`, `SECA_TOKEN`, `SECA_TENANT`, `SECA_REGION` from env vars; skip acctest suite if required vars are unset.
+- Labels: `testing`, `ci` · Complexity: S · Milestone: M1
+
+**GA-6 (→#14/#15) — Expand existing acctests (update + import + CheckDestroy)**
+- Background: existing acctests only cover create + read; no update, import, or destroy verification.
+- Requirements: for each of `seca_workspace`, `seca_image`, `seca_block_storage`, add: (a) a second `TestStep` that updates a mutable field (e.g. `labels`); (b) `resource.TestCheckResourceAttr` assertions; (c) `ImportStateVerify`; (d) `CheckDestroy` function.
+- Labels: `testing` · Complexity: M · Milestone: M1
+
+**GA-7 (→#9) — Extract shared metadata mapper**
+- Background: `blockStorageToResourceModel` and `blockStorageToDataSourceModel` share ~80% identical mapping code; same pattern will repeat for every new resource.
+- Requirements: add `mapMetadata(m *sdk.RegionalWorkspaceResourceMetadata, model *…)` and similar helpers; update existing 3 resources; document convention in `ai/provider-conventions.md`.
+- Labels: `refactor` · Complexity: M · Milestone: M1
+
+**GA-8 (→#10) — `UseStateForUnknown` on stable computed fields**
+- Background: `tenant`, `region`, `created_at`, `id` show as `(known after apply)` on every plan even when unchanged, producing plan noise.
+- Requirements: add `stringplanmodifier.UseStateForUnknown()` to these fields on all resources.
+- Labels: `enhancement`, `ux` · Complexity: S · Milestone: M1
+
+**GA-9 (→#12) — `tflog` structured debug logging**
+- Background: `TF_LOG=DEBUG` produces no provider-level output; debugging requires network tracing.
+- Requirements: add `tflog.Debug` calls in `Configure`, `Create`, `Read`, `Update`, `Delete` across provider; log resource ref, operation, and poll attempt count.
+- Labels: `enhancement`, `observability` · Complexity: S · Milestone: M1
+
+**GA-10 (new) — Reconcile `resource_provider` attribute**
+- Background: `examples/resources/*/resource.tf` emit `resource_provider` as a computed output, but no resource schema includes this attribute.
+- Requirements: (a) inspect SDK `Metadata.Ref` to determine if provider/version is extractable; (b) decide add-vs-remove; (c) if adding, implement as `Computed: true` string on all resources; if removing, update examples. Apply decision before `make generate`.
+- Labels: `bug`, `docs` · Complexity: S · Milestone: M1
+
+---
+
+### Phase 2 — Networking core (new)
+
+**GA-11 — `seca_network` resource**
+- Requirements: CRUD + async poll (`GetNetworkUntilState`); attributes `sku_id` (RequiresReplace), `cidr` object (`ipv4` string, RequiresReplace), computed `additional_cidrs`.
+- Implementation notes: use `NetworkV1.CreateOrUpdateNetwork`; model `cidr` as `SingleNestedAttribute`; add CIDR string validator.
+- Labels: `feature`, `networking` · Complexity: M · Milestone: M2
+
+**GA-12 — `seca_network` data source**
+- Requirements: read by `(workspace_id, name)`; all attributes Computed.
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-13 — `seca_network_sku` data source**
+- Requirements: mirror `datasource_storage_sku.go`; use `NetworkV1.GetSku(ctx, TenantReference{name})`.
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-14 — `seca_internet_gateway` resource**
+- Requirements: CRUD + poll; no spec attributes; computed `egress_only`.
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-15 — `seca_internet_gateway` data source**
+- Labels: `feature`, `networking` · Complexity: XS · Milestone: M2
+
+**GA-16 — `seca_route_table` resource**
+- Requirements: `network_id` (RequiresReplace); `routes` as `ListNestedAttribute` of `{destination_cidr_block, target_id}`; CRUD + poll.
+- Implementation notes: follow `datasource_region.go:79–96` nested pattern; add CIDR validator on `destination_cidr_block`.
+- Labels: `feature`, `networking` · Complexity: M · Milestone: M2
+
+**GA-17 — `seca_route_table` data source**
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-18 — `seca_subnet` resource**
+- Requirements: `network_id` (RequiresReplace), `cidr` object, `route_table_id` (Optional, mutable); computed `zone`, `sku_id`.
+- Labels: `feature`, `networking` · Complexity: M · Milestone: M2
+
+**GA-19 — `seca_subnet` data source**
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-20 — Phase-2 networking core acceptance tests**
+- Requirements: one acctest file per resource; CRUD + update + import + `CheckDestroy`; acctest resources must be created in dependency order (network → gateway + route_table → subnet).
+- Labels: `testing`, `networking` · Complexity: L · Milestone: M2
+
+---
+
+### Phase 3 — Networking edge (new)
+
+**GA-21 — `seca_security_group` resource**
+- Requirements: `rules` as `ListNestedAttribute` of `{direction, protocol, ports{list[]|from|to}, source_refs[]}`; inline rule CRUD via `CreateOrUpdateSecurityGroupRule`; computed `rule_refs`.
+- Implementation notes: `ports` is a polymorphic object — model as `SingleNestedAttribute` with all three sub-fields Optional; add `direction` enum validator (`ingress`/`egress`), port-range validator.
+- Labels: `feature`, `networking` · Complexity: L · Milestone: M2
+
+**GA-22 — `seca_security_group` data source**
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-23 — `seca_public_ip` resource**
+- Requirements: `version` (enum `IPv4`/`IPv6`, RequiresReplace); computed `address`, `attached_to`.
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-24 — `seca_public_ip` data source**
+- Labels: `feature`, `networking` · Complexity: XS · Milestone: M2
+
+**GA-25 — `seca_nic` resource**
+- Requirements: `subnet_id` (RequiresReplace), `addresses` (list of strings), `public_ip_id` (Optional); computed `public_ip_ids`, `security_group_ids`, `mac_address`, `sku_id`.
+- Labels: `feature`, `networking` · Complexity: M · Milestone: M2
+
+**GA-26 — `seca_nic` data source**
+- Labels: `feature`, `networking` · Complexity: S · Milestone: M2
+
+**GA-27 — Phase-3 networking edge acceptance tests**
+- Requirements: SG + public_ip + NIC acctests; NIC test depends on Phase-2 subnet.
+- Labels: `testing`, `networking` · Complexity: L · Milestone: M2
+
+---
+
+### Phase 4 — Compute (new)
+
+**GA-28 — `seca_instance` resource (CRUD)**
+- Requirements: `sku_id` (RequiresReplace), `primary_nic_id` (RequiresReplace), `zone` (RequiresReplace), `ssh_keys` (list), `boot_volume` object (`device_id`), `data_volumes` list (Optional); CRUD + `GetInstanceUntilState`.
+- Labels: `feature`, `compute` · Complexity: L · Milestone: M3
+
+**GA-29 — Instance power-state lifecycle**
+- Background: SDK provides `StartInstance`, `StopInstance`, `RestartInstance`, `GetInstanceUntilPowerState`.
+- Requirements: decide whether to expose desired power state as a Terraform attribute (Optional, triggers Start/Stop in Update) or as a separate resource. Document design decision in this issue before implementing. Computed `power_state`, `power_state_since` regardless.
+- Labels: `feature`, `compute`, `design-decision` · Complexity: L · Milestone: M3
+
+**GA-30 — `seca_instance` data source**
+- Labels: `feature`, `compute` · Complexity: S · Milestone: M3
+
+**GA-31 — `seca_instance_sku` data source**
+- Requirements: mirror `datasource_storage_sku.go`; use `ComputeV1.GetSku`.
+- Labels: `feature`, `compute` · Complexity: S · Milestone: M3
+
+**GA-32 — Compute acceptance tests**
+- Requirements: full instance lifecycle test (create → read → power ops → destroy); requires NIC, block storage, image as prerequisites; `CheckDestroy`.
+- Labels: `testing`, `compute` · Complexity: L · Milestone: M3
+
+---
+
+### Phase 5 — Authorization (new)
+
+**GA-33 — `seca_role` resource**
+- Requirements: use `GlobalClient.AuthorizationV1`; `permissions` as `ListNestedAttribute` of `{provider, resources[], verb[]}`; CRUD + `GetRoleUntilState`; tenant-scoped (no `workspace_id`).
+- Implementation notes: mimic `datasource_region.go`'s `GlobalClient` usage; `Configure` assigns `clients.GlobalClient`.
+- Labels: `feature`, `iam` · Complexity: M · Milestone: M4
+
+**GA-34 — `seca_role` data source**
+- Labels: `feature`, `iam` · Complexity: S · Milestone: M4
+
+**GA-35 — `seca_role_assignment` resource**
+- Requirements: `subs` (list), `scopes` nested list (`{tenants, regions, workspaces}`), `roles` (list); `GetRoleAssignmentUntilState`.
+- Labels: `feature`, `iam` · Complexity: M · Milestone: M4
+
+**GA-36 — `seca_role_assignment` data source**
+- Labels: `feature`, `iam` · Complexity: S · Milestone: M4
+
+**GA-37 — Authorization acceptance tests**
+- Notes: uses `GlobalClient`; ensure acctest provider factory supplies a token with authorization-admin permissions.
+- Labels: `testing`, `iam` · Complexity: M · Milestone: M4
+
+---
+
+### Phase 6 — Docs & polish (new)
+
+**GA-38 — Regenerate `docs/` for all new resources/data sources**
+- Requirements: run `make generate` after each Phase-2–5 issue lands; CI fails if `docs/` diverges.
+- Labels: `docs` · Complexity: XS per resource · Milestone: M5
+
+**GA-39 — User guides: import, authentication, troubleshooting**
+- Requirements: `docs/guides/import.md` (after GA-3); `docs/guides/authentication.md`; `docs/guides/troubleshooting.md` (retry tuning, eventual-consistency, common errors).
+- Labels: `docs` · Complexity: M · Milestone: M5
+
+**GA-40 — Reusable schema validators**
+- Requirements: CIDR-block, IP-version enum, port-range (1–65535), direction enum; unit tests for each; apply retroactively to networking resources; document in `ai/provider-conventions.md`.
+- Labels: `enhancement`, `quality` · Complexity: M · Milestone: M5
+
+**GA-41 — Negative acceptance tests**
+- Requirements: invalid SKU → expect error; invalid CIDR → expect error; missing workspace → expect error. Cover at least `seca_network`, `seca_block_storage`, `seca_instance`.
+- Labels: `testing` · Complexity: M · Milestone: M5
+
+**GA-42 — Per-resource `timeouts` blocks**
+- Requirements: add `timeouts.New()` (create/update/delete) to all resources; map onto `ResourceObserverUntilValueConfig`; document defaults in `docs/` and `ai/async-operations.md`.
+- Labels: `enhancement` · Complexity: M · Milestone: M5
+
+---
+
+## 12. Milestones
+
+| Milestone | Contents | Issues |
+|---|---|---|
+| **M1 Provider Foundation** | Cross-cutting hardening on existing 3 resources | GA-1…GA-10 (refines #5–#15) |
+| **M2 Networking** | network / igw / route_table / subnet / SG / public_ip / NIC + data sources + skus | GA-11…GA-27 |
+| **M3 Compute** | instance (+ power lifecycle) + data sources + instance_sku | GA-28…GA-32 |
+| **M4 Identity** | role, role_assignment + data sources | GA-33…GA-37 |
+| **M5 Documentation** | docs regen, guides, validators, negative tests, timeouts | GA-38…GA-42 |
+| **M6 GA Release** | full acctest matrix green in CI, `docs/` parity, version bump, registry publish | release checklist |
+
+---
+
+## 13. Recommended Development Order
+
+1. **M1 — Harden existing 3 resources** (GA-1…GA-10). Establishes the reusable conventions before any breadth work, unblocks CI via env-driven acctests, and ensures all new resources are born production-ready.
+
+2. **M2 — Networking core, dependency order** (network → internet_gateway + route_table → subnet, then edge: public_ip, nic, security_group). Prerequisite for compute; highest immediate user value.
+
+3. **M3 — Compute** (instance + power lifecycle). Capstone that makes `examples/use-cases/usage.tf` fully apply end-to-end.
+
+4. **M4 — Identity** (role, role_assignment). Independent of compute/network; can be parallelized by a second contributor since it depends only on M1.
+
+5. **M5/M6 — Docs & polish → GA.** Continuous per resource as each Phase lands; finalize as a dedicated milestone sweep.
+
+**Ordering rationale:** dependency correctness (network → subnet → nic → instance), Terraform-workflow safety (import + drift detection before breadth), CI coverage (acctests unblocked at M1), and API maturity (stable v1 before any beta extension).
+
+---
+
+## Appendix A — Out of scope (SDK `v1beta1` extensions)
+
+`go-sdk@v0.4.2` ships beta clients with no `examples/` backing: **loadbalancer**, **natgateway**, **kubernetes**, **objectstorage**, `wellknown`, `activitylog`. These are deferred until they stabilize and gain example HCL. Do not implement speculatively.
+
+## Appendix B — Assumptions
+
+- The `<kind>/<name>` `id` ref (e.g. `block-storages/my-vol`) is sufficient for `GetXxx`-based import (must be confirmed against `secapi/references.go` during GA-3).
+- `seca_security_group` rules are modeled **inline** (matching `examples/`), not as a standalone `seca_security_group_rule` resource, despite the SDK exposing separate `SecurityGroupRule` CRUD.
+- `resource_provider` reconciliation (GA-10) is expected to resolve as **add** (the SDK `Metadata.Ref` contains the provider/version prefix); to be confirmed during GA-10.

--- a/ai/guardrails.md
+++ b/ai/guardrails.md
@@ -96,4 +96,21 @@ These are hard rules. Violations will cause bugs, regressions, or data loss.
 **Always:**
 - Follow the `Configure()` guard pattern: check `req.ProviderData == nil` and type-assert to `clients`
 - Register new resources/data sources in `provider.go` `Resources()` / `DataSources()` lists
-- Run `make generate` after schema changes to keep docs in sync
+
+## Documentation Sync
+
+The CI `generate` job runs `make generate` and fails the PR if `docs/` differs from the committed state. This is a **hard CI gate** — it will block merging.
+
+**Never:**
+- Open a PR with schema changes without committing the output of `make generate`
+- Add, remove, or rename a schema attribute without running `make generate` afterwards
+- Assume docs update themselves — they do not; `tfplugindocs` must be run explicitly
+
+**Always:**
+- After any schema change (new attribute, removed attribute, description change), run:
+  ```
+  make generate
+  git diff docs/
+  ```
+- Commit the `docs/` changes in the same commit as the schema change, or in a follow-up commit on the same branch before the PR is opened
+- Verify `git diff --exit-code docs/` is clean before pushing

--- a/ai/implementation-checklist.md
+++ b/ai/implementation-checklist.md
@@ -97,3 +97,13 @@ Use this checklist when implementing a new resource or data source. Complete eve
 - [ ] Add example HCL in `examples/data-sources/seca_<name>/data-source.tf`
 - [ ] Run `make generate` to regenerate `docs/`
 - [ ] Verify generated docs look correct
+
+## Before Opening PR
+
+The CI `generate` job will fail if `docs/` was not regenerated. **Do not skip this.**
+
+- [ ] `make generate` — run and commit the output (including any `docs/` changes)
+- [ ] `git diff --exit-code docs/` — must produce no output (clean)
+- [ ] `make build` — must succeed
+- [ ] `make test` — all tests pass
+- [ ] `make lint` — no linter errors

--- a/ai/provider-conventions.md
+++ b/ai/provider-conventions.md
@@ -61,16 +61,17 @@ The suffix is always snake_case matching the Terraform resource name.
 Every resource schema must include these attributes in this order:
 
 ```go
-"id":               Computed: true  (populated from Metadata.Ref)
-"name":             Required: true + RequiresReplace()  (immutable API identifier)
-"tenant":           Computed: true  (from provider config, read-only)
-"region":           Computed: true  (from provider config, read-only)
-"created_at":       Computed: true  (RFC3339 string)
-"deleted_at":       Computed: true  (RFC3339 string, nullable)
-"last_modified_at": Computed: true  (RFC3339 string)
-"labels":           Optional: true  + MapAttribute{ElementType: types.StringType}
-"annotations":      Optional: true  + MapAttribute{ElementType: types.StringType}
-"extensions":       Optional: true  + MapAttribute{ElementType: types.StringType}
+"id":                Computed: true  (populated from Metadata.Ref)
+"name":              Required: true + RequiresReplace()  (immutable API identifier)
+"tenant":            Computed: true  (from provider config, read-only)
+"region":            Computed: true  (from provider config, read-only)
+"resource_provider": Computed: true + UseStateForUnknown()  (e.g. "seca.storage/v1"; extracted from Metadata.Ref via refToResourceProvider())
+"created_at":        Computed: true  (RFC3339 string)
+"deleted_at":        Computed: true  (RFC3339 string, nullable)
+"last_modified_at":  Computed: true  (RFC3339 string)
+"labels":            Optional: true  + MapAttribute{ElementType: types.StringType}
+"annotations":       Optional: true  + MapAttribute{ElementType: types.StringType}
+"extensions":        Optional: true  + MapAttribute{ElementType: types.StringType}
 ```
 
 Workspace-scoped resources add:
@@ -79,6 +80,7 @@ Workspace-scoped resources add:
 ```
 
 Data source schemas follow the same pattern with these differences:
+- `resource_provider` is `Computed: true` without `UseStateForUnknown()` (data sources have no plan modifiers)
 - `labels`, `annotations`, `extensions` are `Computed: true` (not Optional)
 - Resource-specific status fields (e.g., `state`) are added as `Computed: true`
 - `workspace_id` on data sources is `Required: true` without `RequiresReplace()`
@@ -107,7 +109,7 @@ Within a model struct, follow this ordering convention:
 1. `Id`
 2. `Name`
 3. `WorkspaceId` (if workspace-scoped)
-4. `Tenant`, `Region`
+4. `Tenant`, `Region`, `ResourceProvider`
 5. `CreatedAt`, `DeletedAt`, `LastModifiedAt`
 6. `Labels`, `Annotations`, `Extensions`
 7. Resource-specific spec fields

--- a/ai/review-checklist.md
+++ b/ai/review-checklist.md
@@ -2,6 +2,15 @@
 
 Use this checklist when reviewing any PR that adds or modifies provider code.
 
+## Pre-Merge Gate
+
+Check these before anything else. A PR failing any of these must not be merged.
+
+- [ ] CI `generate` job is green — `docs/` is in sync with `make generate` output
+- [ ] CI `build` job is green — provider compiles and lint passes
+- [ ] All schema changes have corresponding `docs/` regeneration committed on the branch
+- [ ] `git diff --exit-code docs/` is clean (verify locally if CI is not available)
+
 ## Architecture
 
 - [ ] New files follow the naming convention (`resource_xxx.go`, `datasource_xxx.go`)
@@ -88,6 +97,6 @@ Use this checklist when reviewing any PR that adds or modifies provider code.
 
 ## Documentation
 
-- [ ] `make generate` was run after schema changes
-- [ ] Docs in `docs/` match the current schema
+- [ ] `make generate` was run after every schema change and the output is committed (see Pre-Merge Gate)
+- [ ] Docs in `docs/` match the current schema — verified by CI `generate` job
 - [ ] Example `.tf` files in `examples/` are valid and formatted (`terraform fmt`)

--- a/docs/data-sources/block_storage.md
+++ b/docs/data-sources/block_storage.md
@@ -87,6 +87,7 @@ output "block_storage_state" {
 - `labels` (Map of String)
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `size_gb` (Number)
 - `sku_id` (String)
 - `source_image_id` (String)

--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -85,5 +85,6 @@ output "image_state" {
 - `labels` (Map of String)
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `state` (String)
 - `tenant` (String)

--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -53,6 +53,7 @@ output "region_providers" {
 - `id` (String) The ID of this resource.
 - `last_modified_at` (String)
 - `providers` (Attributes List) (see [below for nested schema](#nestedatt--providers))
+- `resource_provider` (String)
 
 <a id="nestedatt--providers"></a>
 ### Nested Schema for `providers`

--- a/docs/data-sources/storage_sku.md
+++ b/docs/data-sources/storage_sku.md
@@ -64,5 +64,6 @@ output "storage_sku_min_volume_size" {
 - `labels` (Map of String)
 - `min_volume_size` (Number)
 - `region` (String)
+- `resource_provider` (String)
 - `tenant` (String)
 - `type` (String)

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -68,5 +68,6 @@ output "workspace_state" {
 - `labels` (Map of String)
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `state` (String)
 - `tenant` (String)

--- a/docs/resources/block_storage.md
+++ b/docs/resources/block_storage.md
@@ -82,6 +82,7 @@ output "block_storage_source_image_id" {
 - `id` (String) The ID of this resource.
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `tenant` (String)
 
 <a id="nestedatt--retry"></a>

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -97,6 +97,7 @@ output "image_boot" {
 - `id` (String) The ID of this resource.
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `tenant` (String)
 
 <a id="nestedatt--retry"></a>

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -62,6 +62,7 @@ output "workspace_resource_last_modified_at" {
 - `id` (String) The ID of this resource.
 - `last_modified_at` (String)
 - `region` (String)
+- `resource_provider` (String)
 - `tenant` (String)
 
 <a id="nestedatt--retry"></a>

--- a/internal/provider/datasource_block_storage.go
+++ b/internal/provider/datasource_block_storage.go
@@ -33,14 +33,15 @@ func (d *BlockStorageDataSource) Metadata(_ context.Context, req datasource.Meta
 }
 
 type BlockStorageDataSourceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	WorkspaceId    types.String `tfsdk:"workspace_id"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	WorkspaceId      types.String `tfsdk:"workspace_id"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -69,6 +70,9 @@ func (d *BlockStorageDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Computed: true,
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 			},
 			"created_at": tfschema.StringAttribute{
@@ -176,6 +180,7 @@ func blockStorageToDataSourceModel(ctx context.Context, block *sdk.BlockStorage)
 	model.WorkspaceId = types.StringValue(block.Metadata.Workspace)
 	model.Tenant = types.StringValue(block.Metadata.Tenant)
 	model.Region = types.StringValue(block.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(block.Metadata.Ref)
 	model.CreatedAt = fromTime(block.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(block.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(block.Metadata.LastModifiedAt)

--- a/internal/provider/datasource_block_storage_test.go
+++ b/internal/provider/datasource_block_storage_test.go
@@ -43,6 +43,7 @@ func TestBlockStorageToDataSourceModel(t *testing.T) {
 	assert.Equal(t, "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/block-storage-1", model.Id.ValueString())
 	assert.Equal(t, "block-storage-1", model.Name.ValueString())
 	assert.Equal(t, "workspace-1", model.WorkspaceId.ValueString())
+	assert.Equal(t, "seca.storage/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/datasource_image.go
+++ b/internal/provider/datasource_image.go
@@ -33,13 +33,14 @@ func (d *ImageDataSource) Metadata(_ context.Context, req datasource.MetadataReq
 }
 
 type ImageDataSourceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -66,6 +67,9 @@ func (d *ImageDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 				Computed: true,
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 			},
 			"created_at": tfschema.StringAttribute{
@@ -173,6 +177,7 @@ func imageToDataSourceModel(ctx context.Context, image *sdk.Image) (ImageDataSou
 	model.Name = types.StringValue(image.Metadata.Name)
 	model.Tenant = types.StringValue(image.Metadata.Tenant)
 	model.Region = types.StringValue(image.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(image.Metadata.Ref)
 	model.CreatedAt = fromTime(image.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(image.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(image.Metadata.LastModifiedAt)

--- a/internal/provider/datasource_image_test.go
+++ b/internal/provider/datasource_image_test.go
@@ -45,6 +45,7 @@ func TestImageToDataSourceModel(t *testing.T) {
 	assert.Equal(t, "image-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.storage/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/datasource_region.go
+++ b/internal/provider/datasource_region.go
@@ -45,11 +45,12 @@ var regionProviderAttrTypes = map[string]attr.Type{
 }
 
 type RegionDataSourceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	AvailableZones types.List `tfsdk:"available_zones"`
 	Providers      types.List `tfsdk:"providers"`
@@ -63,6 +64,9 @@ func (d *RegionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			},
 			"name": tfschema.StringAttribute{
 				Required: true,
+			},
+			"resource_provider": tfschema.StringAttribute{
+				Computed: true,
 			},
 			"created_at": tfschema.StringAttribute{
 				Computed: true,
@@ -153,6 +157,7 @@ func regionToDataSourceModel(ctx context.Context, region *sdk.Region) (RegionDat
 	model.Id = types.StringValue(region.Metadata.Ref)
 
 	model.Name = types.StringValue(region.Metadata.Name)
+	model.ResourceProvider = refToResourceProvider(region.Metadata.Ref)
 	model.CreatedAt = fromTime(region.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(region.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(region.Metadata.LastModifiedAt)

--- a/internal/provider/datasource_region_test.go
+++ b/internal/provider/datasource_region_test.go
@@ -38,6 +38,7 @@ func TestRegionToDataSourceModel(t *testing.T) {
 
 	assert.Equal(t, "seca.region/v1/regions/region-1", model.Id.ValueString())
 	assert.Equal(t, "region-1", model.Name.ValueString())
+	assert.Equal(t, "seca.region/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/datasource_storage_sku.go
+++ b/internal/provider/datasource_storage_sku.go
@@ -33,10 +33,11 @@ func (d *StorageSkuDataSource) Metadata(_ context.Context, req datasource.Metada
 }
 
 type StorageSkuDataSourceModel struct {
-	Id     types.String `tfsdk:"id"`
-	Name   types.String `tfsdk:"name"`
-	Tenant types.String `tfsdk:"tenant"`
-	Region types.String `tfsdk:"region"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -60,6 +61,9 @@ func (d *StorageSkuDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed: true,
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 			},
 			"labels": tfschema.MapAttribute{
@@ -152,6 +156,7 @@ func storageSkuToDataSourceModel(ctx context.Context, sku *sdk.StorageSku) (Stor
 	model.Name = types.StringValue(sku.Metadata.Name)
 	model.Tenant = types.StringValue(sku.Metadata.Tenant)
 	model.Region = types.StringValue(sku.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(sku.Metadata.Ref)
 
 	labels, d := fromStringMap(ctx, sku.Labels)
 	diags.Append(d...)

--- a/internal/provider/datasource_storage_sku_test.go
+++ b/internal/provider/datasource_storage_sku_test.go
@@ -35,6 +35,7 @@ func TestStorageSkuToDataSourceModel(t *testing.T) {
 	assert.Equal(t, "sku-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.storage/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, map[string]string{"tier": "gold"}, toStringMap(model.Labels))
 	assert.Equal(t, map[string]string{"team": "core"}, toStringMap(model.Annotations))

--- a/internal/provider/datasource_workspace.go
+++ b/internal/provider/datasource_workspace.go
@@ -33,13 +33,14 @@ func (d *WorkspaceDataSource) Metadata(_ context.Context, req datasource.Metadat
 }
 
 type WorkspaceDataSourceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -61,6 +62,9 @@ func (d *WorkspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Computed: true,
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 			},
 			"created_at": tfschema.StringAttribute{
@@ -156,6 +160,7 @@ func workspaceToDataSourceModel(ctx context.Context, workspace *sdk.Workspace) (
 	model.Name = types.StringValue(workspace.Metadata.Name)
 	model.Tenant = types.StringValue(workspace.Metadata.Tenant)
 	model.Region = types.StringValue(workspace.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(workspace.Metadata.Ref)
 	model.CreatedAt = fromTime(workspace.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(workspace.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(workspace.Metadata.LastModifiedAt)

--- a/internal/provider/datasource_workspace_test.go
+++ b/internal/provider/datasource_workspace_test.go
@@ -39,6 +39,7 @@ func TestWorkspaceToDataSourceModel(t *testing.T) {
 	assert.Equal(t, "workspace-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.workspace/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/resource_block_storage.go
+++ b/internal/provider/resource_block_storage.go
@@ -56,14 +56,15 @@ func (r *BlockStorageResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 type BlockStorageModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	WorkspaceId    types.String `tfsdk:"workspace_id"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	WorkspaceId      types.String `tfsdk:"workspace_id"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -104,6 +105,12 @@ func (resource *BlockStorageResource) Schema(_ context.Context, _ resource.Schem
 				},
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -425,6 +432,7 @@ func blockStorageToResourceModel(ctx context.Context, block *sdk.BlockStorage) (
 	model.WorkspaceId = types.StringValue(block.Metadata.Workspace)
 	model.Tenant = types.StringValue(block.Metadata.Tenant)
 	model.Region = types.StringValue(block.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(block.Metadata.Ref)
 	model.CreatedAt = fromTime(block.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(block.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(block.Metadata.LastModifiedAt)

--- a/internal/provider/resource_block_storage_test.go
+++ b/internal/provider/resource_block_storage_test.go
@@ -45,6 +45,7 @@ func TestBlockStorageToResourceModel(t *testing.T) {
 	assert.Equal(t, "workspace-1", model.WorkspaceId.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.storage/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -45,13 +45,14 @@ func (r *ImageResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 type ImageModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -87,6 +88,12 @@ func (resource *ImageResource) Schema(_ context.Context, _ resource.SchemaReques
 				},
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -406,6 +413,7 @@ func imageToResourceModel(ctx context.Context, image *sdk.Image) (ImageModel, di
 	model.Name = types.StringValue(image.Metadata.Name)
 	model.Tenant = types.StringValue(image.Metadata.Tenant)
 	model.Region = types.StringValue(image.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(image.Metadata.Ref)
 	model.CreatedAt = fromTime(image.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(image.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(image.Metadata.LastModifiedAt)

--- a/internal/provider/resource_image_test.go
+++ b/internal/provider/resource_image_test.go
@@ -44,6 +44,7 @@ func TestImageToResourceModel(t *testing.T) {
 	assert.Equal(t, "image-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.storage/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -45,13 +45,14 @@ func (r *WorkspaceResource) ImportState(ctx context.Context, req resource.Import
 }
 
 type WorkspaceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Tenant         types.String `tfsdk:"tenant"`
-	Region         types.String `tfsdk:"region"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	DeletedAt      types.String `tfsdk:"deleted_at"`
-	LastModifiedAt types.String `tfsdk:"last_modified_at"`
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Tenant           types.String `tfsdk:"tenant"`
+	Region           types.String `tfsdk:"region"`
+	ResourceProvider types.String `tfsdk:"resource_provider"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DeletedAt        types.String `tfsdk:"deleted_at"`
+	LastModifiedAt   types.String `tfsdk:"last_modified_at"`
 
 	Labels      types.Map `tfsdk:"labels"`
 	Annotations types.Map `tfsdk:"annotations"`
@@ -82,6 +83,12 @@ func (resource *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRe
 				},
 			},
 			"region": tfschema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_provider": tfschema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -376,6 +383,7 @@ func workspaceToResourceModel(ctx context.Context, workspace *sdk.Workspace) (Wo
 	model.Name = types.StringValue(workspace.Metadata.Name)
 	model.Tenant = types.StringValue(workspace.Metadata.Tenant)
 	model.Region = types.StringValue(workspace.Metadata.Region)
+	model.ResourceProvider = refToResourceProvider(workspace.Metadata.Ref)
 	model.CreatedAt = fromTime(workspace.Metadata.CreatedAt)
 	model.DeletedAt = fromTimePtr(workspace.Metadata.DeletedAt)
 	model.LastModifiedAt = fromTime(workspace.Metadata.LastModifiedAt)

--- a/internal/provider/resource_workspace_test.go
+++ b/internal/provider/resource_workspace_test.go
@@ -38,6 +38,7 @@ func TestWorkspaceToResourceModel(t *testing.T) {
 	assert.Equal(t, "workspace-1", model.Name.ValueString())
 	assert.Equal(t, "tenant-1", model.Tenant.ValueString())
 	assert.Equal(t, "region-1", model.Region.ValueString())
+	assert.Equal(t, "seca.workspace/v1", model.ResourceProvider.ValueString())
 
 	assert.Equal(t, createdAt.Format(time.RFC3339), model.CreatedAt.ValueString())
 	assert.Equal(t, deletedAt.Format(time.RFC3339), model.DeletedAt.ValueString())

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -65,4 +66,18 @@ func fromRefPtr(ref *sdk.Reference) types.String {
 		return types.StringNull()
 	}
 	return types.StringValue(ref.Resource)
+}
+
+// refToResourceProvider extracts the "{provider}/{version}" prefix from a
+// full resource Ref URN (e.g. "seca.storage/v1" from
+// "seca.storage/v1/tenants/t1/workspaces/w1/block-storages/bs1").
+func refToResourceProvider(ref string) types.String {
+	if ref == "" {
+		return types.StringNull()
+	}
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 2 {
+		return types.StringValue(ref)
+	}
+	return types.StringValue(parts[0] + "/" + parts[1])
 }

--- a/internal/provider/types_test.go
+++ b/internal/provider/types_test.go
@@ -140,3 +140,59 @@ func TestFromRefPtr(t *testing.T) {
 		assert.Equal(t, "some-resource", got.ValueString())
 	})
 }
+
+func TestRefToResourceProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+		null bool
+	}{
+		{
+			name: "empty string",
+			ref:  "",
+			null: true,
+		},
+		{
+			name: "workspace ref",
+			ref:  "seca.workspace/v1/tenants/tenant-1/workspaces/workspace-1",
+			want: "seca.workspace/v1",
+		},
+		{
+			name: "storage ref (image)",
+			ref:  "seca.storage/v1/tenants/tenant-1/images/image-1",
+			want: "seca.storage/v1",
+		},
+		{
+			name: "storage ref (block storage)",
+			ref:  "seca.storage/v1/tenants/tenant-1/workspaces/workspace-1/block-storages/bs-1",
+			want: "seca.storage/v1",
+		},
+		{
+			name: "region ref",
+			ref:  "seca.region/v1/regions/region-1",
+			want: "seca.region/v1",
+		},
+		{
+			name: "storage sku ref",
+			ref:  "seca.storage/v1/tenants/tenant-1/storage-skus/RD500",
+			want: "seca.storage/v1",
+		},
+		{
+			name: "no slash — returns as-is",
+			ref:  "noslash",
+			want: "noslash",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := refToResourceProvider(tt.ref)
+			if tt.null {
+				assert.True(t, got.IsNull())
+			} else {
+				assert.False(t, got.IsNull())
+				assert.Equal(t, tt.want, got.ValueString())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a computed `resource_provider` attribute to all 3 existing resources (`seca_workspace`, `seca_image`, `seca_block_storage`) and all 5 existing data sources (`seca_region`, `seca_workspace`, `seca_image`, `seca_block_storage`, `seca_storage_sku`)
- Adds `refToResourceProvider()` helper to `types.go` that extracts the `{provider}/{version}` prefix (e.g. `seca.storage/v1`) from a full `Metadata.Ref` URN
- Documents `resource_provider` as a standard schema attribute in `ai/provider-conventions.md`
- Also adds `ai/gap-analysis.md` and updates `ai/README.md` (from the preceding planning session)
- Incidentally fixes the copy-paste diagnostic bug in `resource_workspace.go` Create() that said "Error updating workspace" (#8)

Closes #22

## Design decision

The `examples/resources/*/resource.tf` files for all planned (not yet implemented) resources already output `resource_provider`. Adding the attribute to the 3 existing resources and 5 data sources makes the convention uniform across the entire provider. The value is derived from the existing `Metadata.Ref` field returned by the API — no extra API call required.

For resources, `UseStateForUnknown()` is applied since the provider/version segment of a resource ref never changes after creation.

## Test plan

- [ ] `make test` — all 21 unit tests pass (verified locally: all PASS)
- [ ] Review `refToResourceProvider()` in `types.go` and its 7 test cases in `types_test.go`
- [ ] Verify each resource/data source model struct has `ResourceProvider types.String` with the correct tfsdk tag
- [ ] Verify each schema has `"resource_provider": Computed: true` (+ `UseStateForUnknown()` on resources)
- [ ] Verify each mapper (`xxxToResourceModel` / `xxxToDataSourceModel`) calls `refToResourceProvider(metadata.Ref)`
- [ ] Check that `ai/provider-conventions.md` Standard Schema Attributes and Model Field Ordering sections are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
