### PR TITLE
M2 PR7: Phase-2 networking core acceptance tests (GA-20)

### DIFF
--- a/internal/acctest/internet_gateway_test.go
+++ b/internal/acctest/internet_gateway_test.go
@@ -1,0 +1,121 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_internet_gateway" {
+			continue
+		}
+
+		wref := secapi.WorkspaceReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetInternetGateway(ctx, wref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking internet gateway %q was destroyed: %w", wref.Name, err)
+		}
+		return fmt.Errorf("internet gateway %q still exists after destroy", wref.Name)
+	}
+
+	return nil
+}
+
+func testAccInternetGatewayResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccInternetGatewayDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+
+  labels = %s
+}
+data "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccInternetGateway(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckInternetGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInternetGatewayResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "name", "internet-gateway-1"),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccInternetGatewayResourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "name", "internet-gateway-1"),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_internet_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/internet-gateway-1",
+			},
+			{
+				Config: testAccInternetGatewayDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "name", "internet-gateway-1"),
+					resource.TestCheckResourceAttr("seca_internet_gateway.test", "workspace_id", "workspace-1"),
+
+					resource.TestCheckResourceAttr("data.seca_internet_gateway.test", "name", "internet-gateway-1"),
+					resource.TestCheckResourceAttr("data.seca_internet_gateway.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_internet_gateway.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_internet_gateway.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_internet_gateway.test", "state", "active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/network_sku_test.go
+++ b/internal/acctest/network_sku_test.go
@@ -1,0 +1,33 @@
+package acctest
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccNetworkSkuDataSourceConfig() string {
+	return testAccProviderConfig() + `
+data "seca_network_sku" "test" {
+  name = "N10K"
+}`
+}
+
+func TestAccNetworkSku(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSkuDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.seca_network_sku.test", "name", "N10K"),
+					resource.TestCheckResourceAttr("data.seca_network_sku.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_network_sku.test", "region", testAccRegion),
+					resource.TestCheckResourceAttrSet("data.seca_network_sku.test", "bandwidth"),
+					resource.TestCheckResourceAttrSet("data.seca_network_sku.test", "packets"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/network_test.go
+++ b/internal/acctest/network_test.go
@@ -1,0 +1,134 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckNetworkDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_network" {
+			continue
+		}
+
+		wref := secapi.WorkspaceReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetNetwork(ctx, wref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking network %q was destroyed: %w", wref.Name, err)
+		}
+		return fmt.Errorf("network %q still exists after destroy", wref.Name)
+	}
+
+	return nil
+}
+
+func testAccNetworkResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccNetworkDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+  labels = %s
+}
+data "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccNetwork(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_network.test", "name", "network-1"),
+					resource.TestCheckResourceAttr("seca_network.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_network.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_network.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_network.test", "sku_id", "N10K"),
+					resource.TestCheckResourceAttr("seca_network.test", "cidr.ipv4", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr("seca_network.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccNetworkResourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_network.test", "name", "network-1"),
+					resource.TestCheckResourceAttr("seca_network.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_network.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/network-1",
+			},
+			{
+				Config: testAccNetworkDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_network.test", "name", "network-1"),
+					resource.TestCheckResourceAttr("seca_network.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_network.test", "sku_id", "N10K"),
+
+					resource.TestCheckResourceAttr("data.seca_network.test", "name", "network-1"),
+					resource.TestCheckResourceAttr("data.seca_network.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_network.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_network.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_network.test", "sku_id", "N10K"),
+					resource.TestCheckResourceAttr("data.seca_network.test", "cidr.ipv4", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr("data.seca_network.test", "state", "active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/route_table_test.go
+++ b/internal/acctest/route_table_test.go
@@ -1,0 +1,207 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckRouteTableDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_route_table" {
+			continue
+		}
+
+		nref := secapi.NetworkReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Network:   secapi.NetworkID(rs.Primary.Attributes["network_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetRouteTable(ctx, nref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking route table %q was destroyed: %w", nref.Name, err)
+		}
+		return fmt.Errorf("route table %q still exists after destroy", nref.Name)
+	}
+
+	return nil
+}
+
+func testAccRouteTableResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  routes = [
+    {
+      destination_cidr_block = "0.0.0.0/0"
+      target_id              = seca_internet_gateway.test.id
+    }
+  ]
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccRouteTableUpdateConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  routes = [
+    {
+      destination_cidr_block = "0.0.0.0/0"
+      target_id              = seca_internet_gateway.test.id
+    },
+    {
+      destination_cidr_block = "10.1.0.0/16"
+      target_id              = seca_internet_gateway.test.id
+    }
+  ]
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccRouteTableDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_internet_gateway" "test" {
+  name         = "internet-gateway-1"
+  workspace_id = seca_workspace.test.name
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  routes = [
+    {
+      destination_cidr_block = "0.0.0.0/0"
+      target_id              = seca_internet_gateway.test.id
+    }
+  ]
+  labels = %s
+}
+data "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccRouteTable(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTableResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_route_table.test", "name", "route-table-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "network_id", "network-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_route_table.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_route_table.test", "routes.#", "1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "routes.0.destination_cidr_block", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccRouteTableUpdateConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_route_table.test", "name", "route-table-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "routes.#", "2"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_route_table.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/network-1/route-table-1",
+			},
+			{
+				Config: testAccRouteTableDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_route_table.test", "name", "route-table-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_route_table.test", "network_id", "network-1"),
+
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "name", "route-table-1"),
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "network_id", "network-1"),
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_route_table.test", "state", "active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/subnet_test.go
+++ b/internal/acctest/subnet_test.go
@@ -1,0 +1,200 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckSubnetDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_subnet" {
+			continue
+		}
+
+		nref := secapi.NetworkReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Network:   secapi.NetworkID(rs.Primary.Attributes["network_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetSubnet(ctx, nref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking subnet %q was destroyed: %w", nref.Name, err)
+		}
+		return fmt.Errorf("subnet %q still exists after destroy", nref.Name)
+	}
+
+	return nil
+}
+
+func testAccSubnetResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+}
+resource "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  cidr = {
+    ipv4 = "10.0.1.0/24"
+  }
+  route_table_id = seca_route_table.test.name
+  labels         = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccSubnetUpdateConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+}
+resource "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  cidr = {
+    ipv4 = "10.0.1.0/24"
+  }
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccSubnetDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_route_table" "test" {
+  name         = "route-table-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+}
+resource "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  cidr = {
+    ipv4 = "10.0.1.0/24"
+  }
+  route_table_id = seca_route_table.test.name
+  labels         = %s
+}
+data "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccSubnet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubnetResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_subnet.test", "name", "subnet-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "network_id", "network-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_subnet.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_subnet.test", "cidr.ipv4", "10.0.1.0/24"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "route_table_id", "route-table-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccSubnetUpdateConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_subnet.test", "name", "subnet-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_subnet.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/network-1/subnet-1",
+			},
+			{
+				Config: testAccSubnetDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_subnet.test", "name", "subnet-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "network_id", "network-1"),
+					resource.TestCheckResourceAttr("seca_subnet.test", "cidr.ipv4", "10.0.1.0/24"),
+
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "name", "subnet-1"),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "network_id", "network-1"),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "cidr.ipv4", "10.0.1.0/24"),
+					resource.TestCheckResourceAttr("data.seca_subnet.test", "state", "active"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Acceptance tests for Phase-2 networking core resources (GA-20, Issue #32)
- Covers:  (data source), , , , 

## Test coverage per resource

| Resource | Create | Labels update | Routes/rules update | Import | Data source |
|---|---|---|---|---|---|
|  | ✓ (data source read) | — | — | — | ✓ |
|  | ✓ | ✓ | — | ✓ | ✓ |
|  | ✓ | ✓ | — | ✓ | ✓ |
|  | ✓ | ✓ | ✓ routes update | ✓ | ✓ |
|  | ✓ | ✓ | ✓ route_table_id update | ✓ | ✓ |

## Notes

- Network-scoped resources (route_table, subnet) use  in 
- Workspace-scoped resources use 
- All tests guarded by ; run against a live SECA cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)