### PR TITLE
M2 PR8: Phase-3 networking edge acceptance tests (GA-27)

### DIFF
--- a/internal/acctest/nic_test.go
+++ b/internal/acctest/nic_test.go
@@ -1,0 +1,161 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckNicDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_nic" {
+			continue
+		}
+
+		wref := secapi.WorkspaceReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetNic(ctx, wref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking NIC %q was destroyed: %w", wref.Name, err)
+		}
+		return fmt.Errorf("NIC %q still exists after destroy", wref.Name)
+	}
+
+	return nil
+}
+
+func testAccNicResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  cidr = {
+    ipv4 = "10.0.1.0/24"
+  }
+}
+resource "seca_nic" "test" {
+  name         = "nic-1"
+  workspace_id = seca_workspace.test.name
+  subnet_id    = seca_subnet.test.id
+
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccNicDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_network" "test" {
+  name         = "network-1"
+  workspace_id = seca_workspace.test.name
+
+  sku_id = "N10K"
+  cidr = {
+    ipv4 = "10.0.0.0/16"
+  }
+}
+resource "seca_subnet" "test" {
+  name         = "subnet-1"
+  workspace_id = seca_workspace.test.name
+  network_id   = seca_network.test.name
+
+  cidr = {
+    ipv4 = "10.0.1.0/24"
+  }
+}
+resource "seca_nic" "test" {
+  name         = "nic-1"
+  workspace_id = seca_workspace.test.name
+  subnet_id    = seca_subnet.test.id
+
+  labels = %s
+}
+data "seca_nic" "test" {
+  name         = "nic-1"
+  workspace_id = seca_workspace.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccNic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNicResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_nic.test", "name", "nic-1"),
+					resource.TestCheckResourceAttr("seca_nic.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_nic.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_nic.test", "region", testAccRegion),
+					resource.TestCheckResourceAttrSet("seca_nic.test", "subnet_id"),
+					resource.TestCheckResourceAttr("seca_nic.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccNicResourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_nic.test", "name", "nic-1"),
+					resource.TestCheckResourceAttr("seca_nic.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_nic.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/nic-1",
+			},
+			{
+				Config: testAccNicDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_nic.test", "name", "nic-1"),
+					resource.TestCheckResourceAttr("seca_nic.test", "workspace_id", "workspace-1"),
+
+					resource.TestCheckResourceAttr("data.seca_nic.test", "name", "nic-1"),
+					resource.TestCheckResourceAttr("data.seca_nic.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_nic.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_nic.test", "region", testAccRegion),
+					resource.TestCheckResourceAttrSet("data.seca_nic.test", "subnet_id"),
+					resource.TestCheckResourceAttr("data.seca_nic.test", "state", "active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/public_ip_test.go
+++ b/internal/acctest/public_ip_test.go
@@ -1,0 +1,126 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckPublicIpDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_public_ip" {
+			continue
+		}
+
+		wref := secapi.WorkspaceReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetPublicIp(ctx, wref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking public IP %q was destroyed: %w", wref.Name, err)
+		}
+		return fmt.Errorf("public IP %q still exists after destroy", wref.Name)
+	}
+
+	return nil
+}
+
+func testAccPublicIpResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_public_ip" "test" {
+  name         = "public-ip-1"
+  workspace_id = seca_workspace.test.name
+
+  version = "IPv4"
+  labels  = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccPublicIpDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_public_ip" "test" {
+  name         = "public-ip-1"
+  workspace_id = seca_workspace.test.name
+
+  version = "IPv4"
+  labels  = %s
+}
+data "seca_public_ip" "test" {
+  name         = "public-ip-1"
+  workspace_id = seca_workspace.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccPublicIp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPublicIpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublicIpResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_public_ip.test", "name", "public-ip-1"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "version", "IPv4"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccPublicIpResourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_public_ip.test", "name", "public-ip-1"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_public_ip.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/public-ip-1",
+			},
+			{
+				Config: testAccPublicIpDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_public_ip.test", "name", "public-ip-1"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_public_ip.test", "version", "IPv4"),
+
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "name", "public-ip-1"),
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "version", "IPv4"),
+					resource.TestCheckResourceAttr("data.seca_public_ip.test", "state", "active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/security_group_test.go
+++ b/internal/acctest/security_group_test.go
@@ -1,0 +1,177 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckSecurityGroupDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccRegionalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_security_group" {
+			continue
+		}
+
+		wref := secapi.WorkspaceReference{
+			Tenant:    secapi.TenantID(testAccTenant),
+			Workspace: secapi.WorkspaceID(rs.Primary.Attributes["workspace_id"]),
+			Name:      rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.NetworkV1.GetSecurityGroup(ctx, wref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking security group %q was destroyed: %w", wref.Name, err)
+		}
+		return fmt.Errorf("security group %q still exists after destroy", wref.Name)
+	}
+
+	return nil
+}
+
+func testAccSecurityGroupResourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_security_group" "test" {
+  name         = "security-group-1"
+  workspace_id = seca_workspace.test.name
+
+  rules = [
+    {
+      direction = "ingress"
+      protocol  = "tcp"
+      ports = {
+        list = [80, 443]
+      }
+      source_refs = []
+    }
+  ]
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccSecurityGroupUpdateConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_security_group" "test" {
+  name         = "security-group-1"
+  workspace_id = seca_workspace.test.name
+
+  rules = [
+    {
+      direction = "ingress"
+      protocol  = "tcp"
+      ports = {
+        list = [80, 443]
+      }
+      source_refs = []
+    },
+    {
+      direction = "ingress"
+      protocol  = "tcp"
+      ports = {
+        from = 22
+      }
+      source_refs = ["55.44.33.11"]
+    }
+  ]
+  labels = %s
+}
+`, formatLabels(labels))
+}
+
+func testAccSecurityGroupDataSourceConfig(labels map[string]string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_workspace" "test" {
+  name = "workspace-1"
+}
+resource "seca_security_group" "test" {
+  name         = "security-group-1"
+  workspace_id = seca_workspace.test.name
+
+  rules = [
+    {
+      direction = "ingress"
+      protocol  = "tcp"
+      ports = {
+        list = [80, 443]
+      }
+      source_refs = []
+    }
+  ]
+  labels = %s
+}
+data "seca_security_group" "test" {
+  name         = "security-group-1"
+  workspace_id = seca_workspace.test.name
+}`, formatLabels(labels))
+}
+
+func TestAccSecurityGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupResourceConfig(map[string]string{"env": "dev"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_security_group.test", "name", "security-group-1"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_security_group.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("seca_security_group.test", "rules.#", "1"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "rules.0.direction", "ingress"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "rules.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "labels.env", "dev"),
+				),
+			},
+			{
+				Config: testAccSecurityGroupUpdateConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_security_group.test", "name", "security-group-1"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "rules.#", "2"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "labels.env", "prod"),
+				),
+			},
+			{
+				ResourceName:      "seca_security_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "workspace-1/security-group-1",
+			},
+			{
+				Config: testAccSecurityGroupDataSourceConfig(map[string]string{"env": "prod"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_security_group.test", "name", "security-group-1"),
+					resource.TestCheckResourceAttr("seca_security_group.test", "workspace_id", "workspace-1"),
+
+					resource.TestCheckResourceAttr("data.seca_security_group.test", "name", "security-group-1"),
+					resource.TestCheckResourceAttr("data.seca_security_group.test", "workspace_id", "workspace-1"),
+					resource.TestCheckResourceAttr("data.seca_security_group.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_security_group.test", "region", testAccRegion),
+					resource.TestCheckResourceAttr("data.seca_security_group.test", "state", "active"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Acceptance tests for Phase-3 networking edge resources (GA-27, Issue #39)
- Covers: seca_security_group, seca_public_ip, seca_nic

## Test coverage per resource

Each test includes: create, labels update, import state, data source read with state=active.

- seca_security_group: also tests updating rules (1 rule -> 2 rules in-place)
- seca_public_ip: tests IPv4 version field
- seca_nic: creates workspace+network+subnet chain as prerequisites, uses subnet.id as subnet_id

## Notes

- All resources are workspace-scoped, using WorkspaceReference in CheckDestroy
- NIC test depends on subnet which depends on network+workspace
- All tests guarded by TF_ACC=1 and require a live SECA cluster

## Test plan

- [ ] Run TF_ACC=1 go test -v -run TestAccSecurityGroup ./internal/acctest/
- [ ] Run TF_ACC=1 go test -v -run TestAccPublicIp ./internal/acctest/
- [ ] Run TF_ACC=1 go test -v -run TestAccNic ./internal/acctest/

Generated with Claude Code