### PR TITLE
GA-42: Per-resource timeouts blocks

### DIFF
--- a/ai/async-operations.md
+++ b/ai/async-operations.md
@@ -22,12 +22,20 @@ ref := secapi.TenantReference{          // or WorkspaceReference for workspace-s
     Name:   result.Metadata.Name,
 }
 
-// Step 3: Configure polling
-// resource.retry holds the provider-level values; .with(data.Retry) overlays
-// any per-resource `retry` block; .untilState builds the observer config.
-config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+// Step 3: Read per-resource timeout (returns default if user didn't set it)
+createTimeout, diags := plan.Timeouts.Create(ctx, 10*time.Minute)
+resp.Diagnostics.Append(diags...)
+if resp.Diagnostics.HasError() {
+    return
+}
 
-// Step 4: Poll until active (or fail)
+// Step 4: Configure polling
+// resource.retry holds the provider-level values; .with(plan.Retry) overlays
+// any per-resource `retry` block; .withTimeout derives MaxAttempts from the
+// timeout / interval; .untilState builds the observer config.
+config := resource.retry.with(plan.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive)
+
+// Step 5: Poll until active (or fail)
 result, err = resource.client.StorageV1.GetXxxUntilState(ctx, ref, config)
 if err != nil {
     resp.Diagnostics.AddError("Error reading Xxx", "...\nError: "+err.Error())
@@ -35,7 +43,46 @@ if err != nil {
 }
 ```
 
-**The result from Step 4 (not Step 1) must be used to populate Terraform state.** The state must reflect the fully provisioned resource, not the intermediate response from the create call.
+**The result from Step 5 (not Step 1) must be used to populate Terraform state.** The state must reflect the fully provisioned resource, not the intermediate response from the create call.
+
+After writing state, always restore the user-supplied `Timeouts` value so it is persisted:
+```go
+state.Timeouts = plan.Timeouts
+resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+```
+
+## Timeouts
+
+Every resource exposes a standard `timeouts` block that lets users set a ceiling on how long each operation may run:
+
+```hcl
+resource "seca_workspace" "example" {
+  name = "my-workspace"
+
+  timeouts {
+    create = "20m"
+    update = "20m"
+    delete = "15m"
+  }
+}
+```
+
+Internally, `withTimeout(d)` on `retryConfig` derives `MaxAttempts = ceil(d / interval)`. If no timeout is specified, the per-resource default is used (declared in the `Create`/`Update`/`Delete` call sites). See the table below for defaults.
+
+| Resource | Create / Update | Delete |
+|---|---|---|
+| `seca_workspace` | 10 m | 10 m |
+| `seca_image` | 15 m | 15 m |
+| `seca_block_storage` | 10 m | 10 m |
+| `seca_network` | 5 m | 5 m |
+| `seca_internet_gateway` | 5 m | 5 m |
+| `seca_route_table` | 5 m | 5 m |
+| `seca_subnet` | 5 m | 5 m |
+| `seca_security_group` | 5 m | 5 m |
+| `seca_public_ip` | 5 m | 5 m |
+| `seca_nic` | 5 m | 5 m |
+| `seca_role` | 5 m | 5 m |
+| `seca_instance` | 20 m | 20 m |
 
 ## Retry Configuration
 
@@ -53,7 +100,7 @@ Retry parameters resolve through three layers, each overriding the previous **pe
 
 `Delay` is the initial wait before the first poll (allows the API time to begin provisioning). `Interval` is the wait between subsequent polls.
 
-Each resource stores the resolved provider-level values in `resource.retry` (a `retryConfig`, set in `Configure()`). The optional per-resource block lives on the model as `Retry *SecaRetryModel` and is declared in the schema with the shared `retryResourceSchema()` helper. In Create/Update/Delete, `resource.retry.with(data.Retry)` overlays the per-resource block on top of the inherited values before building the observer config (`.untilState(...)` for Create/Update, `.observer()` for Delete). All of this lives in `retry.go`.
+Each resource stores the resolved provider-level values in `resource.retry` (a `retryConfig`, set in `Configure()`). The optional per-resource block lives on the model as `Retry *RetryModel` and is declared in the schema with the shared `retryResourceSchema()` helper. In Create/Update/Delete, `resource.retry.with(plan.Retry).withTimeout(timeout)` overlays the per-resource block and timeout-derived MaxAttempts on top of the inherited values before building the observer config (`.untilState(...)` for Create/Update, `.observer()` for Delete). All of this lives in `retry.go`.
 
 ```hcl
 provider "seca" {
@@ -84,12 +131,13 @@ Always use the **result from the initial API call** to populate the reference (e
 
 ## Delete Operations
 
-`Delete()` submits the deletion with `DeleteXxx()`, then polls `WatchXxxUntilDeleted(ctx, ref, config)` — using the same reference and the same resolved retry config (`resource.retry.with(data.Retry).observer()`) as the Create/Update polling — before returning. This ensures the resource is fully gone on the API side, so a subsequent create of a same-named resource does not conflict. On a polling error, surface it with the read verb: `resp.Diagnostics.AddError("Error reading Xxx", "...while waiting for the Xxx to become deleted.\nError: "+err.Error())`.
+`Delete()` submits the deletion with `DeleteXxx()`, then polls `WatchXxxUntilDeleted(ctx, ref, config)` — using the same reference and the same resolved retry config (`resource.retry.with(data.Retry).withTimeout(deleteTimeout).observer()`) as the Create/Update polling — before returning. This ensures the resource is fully gone on the API side, so a subsequent create of a same-named resource does not conflict. On a polling error, surface it with the read verb: `resp.Diagnostics.AddError("Error reading Xxx", "...while waiting for the Xxx to become deleted.\nError: "+err.Error())`.
 
 ## What NOT to Do
 
 - Never write state from the Step 1 result. Always use the Step 4 (poll) result.
 - Never skip the polling step for Create or Update, even for "fast" resources.
 - Never use `time.Sleep` directly. Always use `GetXxxUntilState()`.
-- Never hard-code delay/interval values. Always resolve through `resource.retry.with(data.Retry)`.
+- Never hard-code delay/interval values. Always resolve through `resource.retry.with(plan.Retry).withTimeout(timeout)`.
 - Never ignore the error from `GetXxxUntilState()`.
+- Never forget to set `state.Timeouts = plan.Timeouts` before writing state in Create/Update.

--- a/docs/resources/block_storage.md
+++ b/docs/resources/block_storage.md
@@ -74,6 +74,7 @@ output "block_storage_source_image_id" {
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
 - `source_image_id` (String)
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -93,6 +94,17 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -89,6 +89,7 @@ output "image_boot" {
 - `initializer` (String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -108,6 +109,17 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/docs/resources/internet_gateway.md
+++ b/docs/resources/internet_gateway.md
@@ -71,6 +71,7 @@ output "internet_gateway_egress_only" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -90,3 +91,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -88,6 +88,7 @@ output "network_additional_cidrs" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -125,3 +126,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -95,6 +95,7 @@ output "nic_mac_address" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -118,3 +119,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -82,6 +82,7 @@ output "public_ip_ip_address" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -104,3 +105,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -75,6 +75,7 @@ output "role_permissions" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -103,3 +104,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/route_table.md
+++ b/docs/resources/route_table.md
@@ -93,6 +93,7 @@ output "route_table_routes" {
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
 - `routes` (Attributes List) (see [below for nested schema](#nestedatt--routes))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -121,3 +122,14 @@ Required:
 
 - `destination_cidr_block` (String)
 - `target_id` (String)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -95,6 +95,7 @@ output "security_group_rule_refs" {
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -138,3 +139,15 @@ Optional:
 - `from` (Number)
 - `list` (List of Number)
 - `to` (Number)
+
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -102,6 +102,7 @@ output "subnet_zone" {
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
 - `route_table_id` (String)
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -132,3 +133,14 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -54,6 +54,7 @@ output "workspace_resource_last_modified_at" {
 - `extensions` (Map of String)
 - `labels` (Map of String)
 - `retry` (Attributes) (see [below for nested schema](#nestedatt--retry))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -73,6 +74,17 @@ Optional:
 - `delay` (Number)
 - `interval` (Number)
 - `max_attempts` (Number)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.26.4
 require (
 	github.com/eu-sovereign-cloud/go-sdk v0.4.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
+	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -37,7 +39,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 h1:jblRy1PkLfPm5hb5XeMa3tezusnMRziUGqtT5epSYoI=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0/go.mod h1:5jm2XK8uqrdiSRfD5O47OoxyGMCnwTcl8eoiDgSa+tc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/internal/provider/resource_block_storage.go
+++ b/internal/provider/resource_block_storage.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_block_storage.go
+++ b/internal/provider/resource_block_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -58,11 +60,15 @@ func (r *BlockStorageResource) ImportState(ctx context.Context, req resource.Imp
 type BlockStorageResourceModel struct {
 	blockStorageModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (resource *BlockStorageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (resource *BlockStorageResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -183,6 +189,12 @@ func (resource *BlockStorageResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "creating block storage")
 
@@ -209,7 +221,7 @@ func (resource *BlockStorageResource) Create(ctx context.Context, req resource.C
 		Name:      block.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive)
 
 	block, err = resource.client.StorageV1.GetBlockStorageUntilState(ctx, wref, config)
 	if err != nil {
@@ -220,11 +232,13 @@ func (resource *BlockStorageResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	data, diags := blockStorageToResourceModel(ctx, block)
-	resp.Diagnostics.Append(diags...)
+	savedTimeouts := data.Timeouts
+	data, diags2 := blockStorageToResourceModel(ctx, block)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Timeouts = savedTimeouts
 
 	tflog.Info(ctx, "block storage created")
 
@@ -278,6 +292,12 @@ func (resource *BlockStorageResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "updating block storage")
 
@@ -304,7 +324,7 @@ func (resource *BlockStorageResource) Update(ctx context.Context, req resource.U
 		Name:      block.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive)
 
 	block, err = resource.client.StorageV1.GetBlockStorageUntilState(ctx, wref, config)
 	if err != nil {
@@ -315,11 +335,13 @@ func (resource *BlockStorageResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	data, diags := blockStorageToResourceModel(ctx, block)
-	resp.Diagnostics.Append(diags...)
+	savedTimeouts := data.Timeouts
+	data, diags2 := blockStorageToResourceModel(ctx, block)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Timeouts = savedTimeouts
 
 	tflog.Info(ctx, "block storage updated")
 
@@ -329,6 +351,12 @@ func (resource *BlockStorageResource) Update(ctx context.Context, req resource.U
 func (resource *BlockStorageResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data BlockStorageResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -365,7 +393,7 @@ func (resource *BlockStorageResource) Delete(ctx context.Context, req resource.D
 		Name:      block.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).observer()
+	config := resource.retry.with(data.Retry).withTimeout(deleteTimeout).observer()
 
 	err = resource.client.StorageV1.WatchBlockStorageUntilDeleted(ctx, wref, config)
 	if err != nil {

--- a/internal/provider/resource_block_storage.go
+++ b/internal/provider/resource_block_storage.go
@@ -195,6 +195,9 @@ func (resource *BlockStorageResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "creating block storage")
 
@@ -298,6 +301,9 @@ func (resource *BlockStorageResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "updating block storage")
 
@@ -360,6 +366,9 @@ func (resource *BlockStorageResource) Delete(ctx context.Context, req resource.D
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting block storage")

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -47,11 +49,15 @@ func (r *ImageResource) ImportState(ctx context.Context, req resource.ImportStat
 type ImageResourceModel struct {
 	imageModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (resource *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (resource *ImageResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -170,6 +176,12 @@ func (resource *ImageResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 15*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "creating image")
 
@@ -195,7 +207,7 @@ func (resource *ImageResource) Create(ctx context.Context, req resource.CreateRe
 		Name:   image.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive)
 
 	image, err = resource.client.StorageV1.GetImageUntilState(ctx, tref, config)
 	if err != nil {
@@ -206,11 +218,13 @@ func (resource *ImageResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	data, diags := imageToResourceModel(ctx, image)
-	resp.Diagnostics.Append(diags...)
+	savedTimeouts := data.Timeouts
+	data, diags2 := imageToResourceModel(ctx, image)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Timeouts = savedTimeouts
 
 	tflog.Info(ctx, "image created")
 
@@ -263,6 +277,12 @@ func (resource *ImageResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 15*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "updating image")
 
@@ -288,7 +308,7 @@ func (resource *ImageResource) Update(ctx context.Context, req resource.UpdateRe
 		Name:   image.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive)
 
 	image, err = resource.client.StorageV1.GetImageUntilState(ctx, tref, config)
 	if err != nil {
@@ -299,11 +319,13 @@ func (resource *ImageResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	data, diags := imageToResourceModel(ctx, image)
-	resp.Diagnostics.Append(diags...)
+	savedTimeouts := data.Timeouts
+	data, diags2 := imageToResourceModel(ctx, image)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Timeouts = savedTimeouts
 
 	tflog.Info(ctx, "image updated")
 
@@ -313,6 +335,12 @@ func (resource *ImageResource) Update(ctx context.Context, req resource.UpdateRe
 func (resource *ImageResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data ImageResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 15*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -347,7 +375,7 @@ func (resource *ImageResource) Delete(ctx context.Context, req resource.DeleteRe
 		Name:   image.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).observer()
+	config := resource.retry.with(data.Retry).withTimeout(deleteTimeout).observer()
 
 	err = resource.client.StorageV1.WatchImageUntilDeleted(ctx, tref, config)
 	if err != nil {

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -182,6 +182,9 @@ func (resource *ImageResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "creating image")
 
@@ -283,6 +286,9 @@ func (resource *ImageResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "updating image")
 
@@ -344,6 +350,9 @@ func (resource *ImageResource) Delete(ctx context.Context, req resource.DeleteRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting image")

--- a/internal/provider/resource_internet_gateway.go
+++ b/internal/provider/resource_internet_gateway.go
@@ -192,6 +192,9 @@ func (r *InternetGatewayResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating internet gateway")
 
@@ -286,6 +289,9 @@ func (r *InternetGatewayResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating internet gateway")
 
@@ -341,6 +347,9 @@ func (r *InternetGatewayResource) Delete(ctx context.Context, req resource.Delet
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting internet gateway")

--- a/internal/provider/resource_internet_gateway.go
+++ b/internal/provider/resource_internet_gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -59,11 +61,15 @@ func (r *InternetGatewayResource) ImportState(ctx context.Context, req resource.
 type InternetGatewayResourceModel struct {
 	internetGatewayModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *InternetGatewayResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *InternetGatewayResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -180,6 +186,12 @@ func (r *InternetGatewayResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating internet gateway")
 
@@ -202,7 +214,7 @@ func (r *InternetGatewayResource) Create(ctx context.Context, req resource.Creat
 		Name:      gtw.Metadata.Name,
 	}
 
-	gtw, err = r.client.NetworkV1.GetInternetGatewayUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	gtw, err = r.client.NetworkV1.GetInternetGatewayUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading internet gateway",
@@ -211,11 +223,12 @@ func (r *InternetGatewayResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	result, diags := internetGatewayToResourceModel(ctx, gtw)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := internetGatewayToResourceModel(ctx, gtw)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "internet gateway created")
 
@@ -267,6 +280,12 @@ func (r *InternetGatewayResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating internet gateway")
 
@@ -289,7 +308,7 @@ func (r *InternetGatewayResource) Update(ctx context.Context, req resource.Updat
 		Name:      gtw.Metadata.Name,
 	}
 
-	gtw, err = r.client.NetworkV1.GetInternetGatewayUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	gtw, err = r.client.NetworkV1.GetInternetGatewayUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading internet gateway",
@@ -298,11 +317,12 @@ func (r *InternetGatewayResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	result, diags := internetGatewayToResourceModel(ctx, gtw)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := internetGatewayToResourceModel(ctx, gtw)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "internet gateway updated")
 
@@ -312,6 +332,12 @@ func (r *InternetGatewayResource) Update(ctx context.Context, req resource.Updat
 func (r *InternetGatewayResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data InternetGatewayResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -344,7 +370,7 @@ func (r *InternetGatewayResource) Delete(ctx context.Context, req resource.Delet
 		Name:      gtw.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchInternetGatewayUntilDeleted(ctx, wref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchInternetGatewayUntilDeleted(ctx, wref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading internet gateway",

--- a/internal/provider/resource_internet_gateway.go
+++ b/internal/provider/resource_internet_gateway.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -229,6 +229,9 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating network")
 
@@ -323,6 +326,9 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating network")
 
@@ -378,6 +384,9 @@ func (r *NetworkResource) Delete(ctx context.Context, req resource.DeleteRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting network")

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -71,10 +73,11 @@ var networkCidrAttrTypes = map[string]attr.Type{
 type NetworkResourceModel struct {
 	networkModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *NetworkResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *NetworkResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	cidrAttrs := map[string]tfschema.Attribute{
 		"ipv4": tfschema.StringAttribute{
 			Optional: true,
@@ -87,6 +90,9 @@ func (r *NetworkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	}
 
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -217,6 +223,12 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating network")
 
@@ -239,7 +251,7 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		Name:      net.Metadata.Name,
 	}
 
-	net, err = r.client.NetworkV1.GetNetworkUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	net, err = r.client.NetworkV1.GetNetworkUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading network",
@@ -248,11 +260,12 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	result, diags := networkToResourceModel(ctx, net)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := networkToResourceModel(ctx, net)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "network created")
 
@@ -304,6 +317,12 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating network")
 
@@ -326,7 +345,7 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 		Name:      net.Metadata.Name,
 	}
 
-	net, err = r.client.NetworkV1.GetNetworkUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	net, err = r.client.NetworkV1.GetNetworkUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading network",
@@ -335,11 +354,12 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	result, diags := networkToResourceModel(ctx, net)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := networkToResourceModel(ctx, net)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "network updated")
 
@@ -349,6 +369,12 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 func (r *NetworkResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data NetworkResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -381,7 +407,7 @@ func (r *NetworkResource) Delete(ctx context.Context, req resource.DeleteRequest
 		Name:      net.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchNetworkUntilDeleted(ctx, wref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchNetworkUntilDeleted(ctx, wref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading network",

--- a/internal/provider/resource_nic.go
+++ b/internal/provider/resource_nic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -60,11 +62,15 @@ func (r *NicResource) ImportState(ctx context.Context, req resource.ImportStateR
 type NicResourceModel struct {
 	nicModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *NicResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *NicResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -213,6 +219,12 @@ func (r *NicResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating nic")
 
@@ -239,7 +251,7 @@ func (r *NicResource) Create(ctx context.Context, req resource.CreateRequest, re
 		Name:      nic.Metadata.Name,
 	}
 
-	nic, err = r.client.NetworkV1.GetNicUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	nic, err = r.client.NetworkV1.GetNicUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading nic",
@@ -248,11 +260,12 @@ func (r *NicResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	result, diags := nicToResourceModel(ctx, nic)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := nicToResourceModel(ctx, nic)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "nic created")
 
@@ -304,6 +317,12 @@ func (r *NicResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating nic")
 
@@ -330,7 +349,7 @@ func (r *NicResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		Name:      nic.Metadata.Name,
 	}
 
-	nic, err = r.client.NetworkV1.GetNicUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	nic, err = r.client.NetworkV1.GetNicUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading nic",
@@ -339,11 +358,12 @@ func (r *NicResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
-	result, diags := nicToResourceModel(ctx, nic)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := nicToResourceModel(ctx, nic)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "nic updated")
 
@@ -353,6 +373,12 @@ func (r *NicResource) Update(ctx context.Context, req resource.UpdateRequest, re
 func (r *NicResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data NicResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -385,7 +411,7 @@ func (r *NicResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		Name:      nic.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchNicUntilDeleted(ctx, wref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchNicUntilDeleted(ctx, wref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading nic",

--- a/internal/provider/resource_nic.go
+++ b/internal/provider/resource_nic.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_nic.go
+++ b/internal/provider/resource_nic.go
@@ -225,6 +225,9 @@ func (r *NicResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating nic")
 
@@ -323,6 +326,9 @@ func (r *NicResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating nic")
 
@@ -382,6 +388,9 @@ func (r *NicResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting nic")

--- a/internal/provider/resource_public_ip.go
+++ b/internal/provider/resource_public_ip.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_public_ip.go
+++ b/internal/provider/resource_public_ip.go
@@ -205,6 +205,9 @@ func (r *PublicIpResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating public ip")
 
@@ -299,6 +302,9 @@ func (r *PublicIpResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating public ip")
 
@@ -354,6 +360,9 @@ func (r *PublicIpResource) Delete(ctx context.Context, req resource.DeleteReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting public ip")

--- a/internal/provider/resource_public_ip.go
+++ b/internal/provider/resource_public_ip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -58,11 +60,15 @@ func (r *PublicIpResource) ImportState(ctx context.Context, req resource.ImportS
 type PublicIpResourceModel struct {
 	publicIpModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *PublicIpResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *PublicIpResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -193,6 +199,12 @@ func (r *PublicIpResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating public ip")
 
@@ -215,7 +227,7 @@ func (r *PublicIpResource) Create(ctx context.Context, req resource.CreateReques
 		Name:      ip.Metadata.Name,
 	}
 
-	ip, err = r.client.NetworkV1.GetPublicIpUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	ip, err = r.client.NetworkV1.GetPublicIpUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading public ip",
@@ -224,11 +236,12 @@ func (r *PublicIpResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	result, diags := publicIpToResourceModel(ctx, ip)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := publicIpToResourceModel(ctx, ip)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "public ip created")
 
@@ -280,6 +293,12 @@ func (r *PublicIpResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating public ip")
 
@@ -302,7 +321,7 @@ func (r *PublicIpResource) Update(ctx context.Context, req resource.UpdateReques
 		Name:      ip.Metadata.Name,
 	}
 
-	ip, err = r.client.NetworkV1.GetPublicIpUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	ip, err = r.client.NetworkV1.GetPublicIpUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading public ip",
@@ -311,11 +330,12 @@ func (r *PublicIpResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	result, diags := publicIpToResourceModel(ctx, ip)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := publicIpToResourceModel(ctx, ip)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "public ip updated")
 
@@ -325,6 +345,12 @@ func (r *PublicIpResource) Update(ctx context.Context, req resource.UpdateReques
 func (r *PublicIpResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data PublicIpResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -357,7 +383,7 @@ func (r *PublicIpResource) Delete(ctx context.Context, req resource.DeleteReques
 		Name:      ip.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchPublicIpUntilDeleted(ctx, wref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchPublicIpUntilDeleted(ctx, wref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading public ip",

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -39,11 +41,15 @@ func (r *RoleResource) Metadata(_ context.Context, req resource.MetadataRequest,
 
 type RoleResourceModel struct {
 	roleModel
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *RoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *RoleResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -170,6 +176,12 @@ func (r *RoleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating role")
 
@@ -191,7 +203,7 @@ func (r *RoleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		Name:   role.Metadata.Name,
 	}
 
-	config := r.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive)
 
 	role, err = r.client.AuthorizationV1.GetRoleUntilState(ctx, tref, config)
 	if err != nil {
@@ -202,13 +214,14 @@ func (r *RoleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	result, diags := roleToResourceModel(ctx, role)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := roleToResourceModel(ctx, role)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	result.Retry = data.Retry
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "role created")
 
@@ -261,6 +274,12 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating role")
 
@@ -282,7 +301,7 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		Name:   role.Metadata.Name,
 	}
 
-	config := r.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive)
 
 	role, err = r.client.AuthorizationV1.GetRoleUntilState(ctx, tref, config)
 	if err != nil {
@@ -293,13 +312,14 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	result, diags := roleToResourceModel(ctx, role)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := roleToResourceModel(ctx, role)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	result.Retry = data.Retry
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "role updated")
 
@@ -309,6 +329,12 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 func (r *RoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data RoleResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -339,7 +365,7 @@ func (r *RoleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		Name:   data.Name.ValueString(),
 	}
 
-	config := r.retry.with(data.Retry).observer()
+	config := r.retry.with(data.Retry).withTimeout(deleteTimeout).observer()
 
 	err = r.client.AuthorizationV1.WatchRoleUntilDeleted(ctx, tref, config)
 	if err != nil {

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -182,6 +182,9 @@ func (r *RoleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating role")
 
@@ -280,6 +283,9 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating role")
 
@@ -338,6 +344,9 @@ func (r *RoleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting role")

--- a/internal/provider/resource_route_table.go
+++ b/internal/provider/resource_route_table.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_route_table.go
+++ b/internal/provider/resource_route_table.go
@@ -216,6 +216,9 @@ func (r *RouteTableResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating route table")
 
@@ -316,6 +319,9 @@ func (r *RouteTableResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating route table")
 
@@ -376,6 +382,9 @@ func (r *RouteTableResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting route table")

--- a/internal/provider/resource_route_table.go
+++ b/internal/provider/resource_route_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -71,11 +73,15 @@ type RouteModel struct {
 type RouteTableResourceModel struct {
 	routeTableModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *RouteTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *RouteTableResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -204,6 +210,12 @@ func (r *RouteTableResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating route table")
 
@@ -231,7 +243,7 @@ func (r *RouteTableResource) Create(ctx context.Context, req resource.CreateRequ
 		Name:      rt.Metadata.Name,
 	}
 
-	rt, err = r.client.NetworkV1.GetRouteTableUntilState(ctx, nref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	rt, err = r.client.NetworkV1.GetRouteTableUntilState(ctx, nref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading route table",
@@ -240,11 +252,12 @@ func (r *RouteTableResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	result, diags := routeTableToResourceModel(ctx, rt)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := routeTableToResourceModel(ctx, rt)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "route table created")
 
@@ -297,6 +310,12 @@ func (r *RouteTableResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating route table")
 
@@ -324,7 +343,7 @@ func (r *RouteTableResource) Update(ctx context.Context, req resource.UpdateRequ
 		Name:      rt.Metadata.Name,
 	}
 
-	rt, err = r.client.NetworkV1.GetRouteTableUntilState(ctx, nref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	rt, err = r.client.NetworkV1.GetRouteTableUntilState(ctx, nref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading route table",
@@ -333,11 +352,12 @@ func (r *RouteTableResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	result, diags := routeTableToResourceModel(ctx, rt)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := routeTableToResourceModel(ctx, rt)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "route table updated")
 
@@ -347,6 +367,12 @@ func (r *RouteTableResource) Update(ctx context.Context, req resource.UpdateRequ
 func (r *RouteTableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data RouteTableResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -381,7 +407,7 @@ func (r *RouteTableResource) Delete(ctx context.Context, req resource.DeleteRequ
 		Name:      rt.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchRouteTableUntilDeleted(ctx, nref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchRouteTableUntilDeleted(ctx, nref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading route table",

--- a/internal/provider/resource_security_group.go
+++ b/internal/provider/resource_security_group.go
@@ -250,6 +250,9 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating security group")
 
@@ -348,6 +351,9 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating security group")
 
@@ -407,6 +413,9 @@ func (r *SecurityGroupResource) Delete(ctx context.Context, req resource.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting security group")

--- a/internal/provider/resource_security_group.go
+++ b/internal/provider/resource_security_group.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_security_group.go
+++ b/internal/provider/resource_security_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -86,10 +88,11 @@ type SGRuleModel struct {
 type SecurityGroupResourceModel struct {
 	securityGroupModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *SecurityGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *SecurityGroupResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	portsAttrs := map[string]tfschema.Attribute{
 		"from": tfschema.Int64Attribute{Optional: true},
 		"to":   tfschema.Int64Attribute{Optional: true},
@@ -113,6 +116,9 @@ func (r *SecurityGroupResource) Schema(_ context.Context, _ resource.SchemaReque
 	}
 
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -238,6 +244,12 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating security group")
 
@@ -264,7 +276,7 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		Name:      sg.Metadata.Name,
 	}
 
-	sg, err = r.client.NetworkV1.GetSecurityGroupUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	sg, err = r.client.NetworkV1.GetSecurityGroupUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading security group",
@@ -273,11 +285,12 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	result, diags := securityGroupToResourceModel(ctx, sg)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := securityGroupToResourceModel(ctx, sg)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "security group created")
 
@@ -329,6 +342,12 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating security group")
 
@@ -355,7 +374,7 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 		Name:      sg.Metadata.Name,
 	}
 
-	sg, err = r.client.NetworkV1.GetSecurityGroupUntilState(ctx, wref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	sg, err = r.client.NetworkV1.GetSecurityGroupUntilState(ctx, wref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading security group",
@@ -364,11 +383,12 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	result, diags := securityGroupToResourceModel(ctx, sg)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := securityGroupToResourceModel(ctx, sg)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "security group updated")
 
@@ -378,6 +398,12 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 func (r *SecurityGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data SecurityGroupResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -410,7 +436,7 @@ func (r *SecurityGroupResource) Delete(ctx context.Context, req resource.DeleteR
 		Name:      sg.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchSecurityGroupUntilDeleted(ctx, wref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchSecurityGroupUntilDeleted(ctx, wref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading security group",

--- a/internal/provider/resource_subnet.go
+++ b/internal/provider/resource_subnet.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/resource_subnet.go
+++ b/internal/provider/resource_subnet.go
@@ -225,6 +225,9 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating subnet")
 
@@ -321,6 +324,9 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating subnet")
 
@@ -377,6 +383,9 @@ func (r *SubnetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting subnet")

--- a/internal/provider/resource_subnet.go
+++ b/internal/provider/resource_subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -65,16 +67,20 @@ type SubnetCidrModel struct {
 type SubnetResourceModel struct {
 	subnetModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (r *SubnetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *SubnetResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	cidrAttrs := map[string]tfschema.Attribute{
 		"ipv4": tfschema.StringAttribute{Optional: true, Computed: true},
 		"ipv6": tfschema.StringAttribute{Optional: true, Computed: true},
 	}
 
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -213,6 +219,12 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "creating subnet")
 
@@ -236,7 +248,7 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		Name:      sub.Metadata.Name,
 	}
 
-	sub, err = r.client.NetworkV1.GetSubnetUntilState(ctx, nref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	sub, err = r.client.NetworkV1.GetSubnetUntilState(ctx, nref, r.retry.with(data.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading subnet",
@@ -245,11 +257,12 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	result, diags := subnetToResourceModel(ctx, sub)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := subnetToResourceModel(ctx, sub)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "subnet created")
 
@@ -302,6 +315,12 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	updateTimeout, diags := data.Timeouts.Update(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = r.logFields(ctx, data)
 	tflog.Debug(ctx, "updating subnet")
 
@@ -325,7 +344,7 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		Name:      sub.Metadata.Name,
 	}
 
-	sub, err = r.client.NetworkV1.GetSubnetUntilState(ctx, nref, r.retry.with(data.Retry).untilState(sdk.ResourceStateActive))
+	sub, err = r.client.NetworkV1.GetSubnetUntilState(ctx, nref, r.retry.with(data.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading subnet",
@@ -334,11 +353,12 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	result, diags := subnetToResourceModel(ctx, sub)
-	resp.Diagnostics.Append(diags...)
+	result, diags2 := subnetToResourceModel(ctx, sub)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	result.Timeouts = data.Timeouts
 
 	tflog.Info(ctx, "subnet updated")
 
@@ -348,6 +368,12 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 func (r *SubnetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data SubnetResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 5*time.Minute)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -382,7 +408,7 @@ func (r *SubnetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		Name:      sub.Metadata.Name,
 	}
 
-	err = r.client.NetworkV1.WatchSubnetUntilDeleted(ctx, nref, r.retry.with(data.Retry).observer())
+	err = r.client.NetworkV1.WatchSubnetUntilDeleted(ctx, nref, r.retry.with(data.Retry).withTimeout(deleteTimeout).observer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading subnet",

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -168,6 +168,9 @@ func (resource *WorkspaceResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, plan)
 	tflog.Debug(ctx, "creating workspace")
 
@@ -272,6 +275,9 @@ func (resource *WorkspaceResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
 	ctx = resource.logFields(ctx, plan)
 	tflog.Debug(ctx, "updating workspace")
 
@@ -336,6 +342,9 @@ func (resource *WorkspaceResource) Delete(ctx context.Context, req resource.Dele
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting workspace")

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -47,11 +49,15 @@ func (r *WorkspaceResource) ImportState(ctx context.Context, req resource.Import
 type WorkspaceResourceModel struct {
 	workspaceModel
 
-	Retry *RetryModel `tfsdk:"retry"`
+	Retry    *RetryModel    `tfsdk:"retry"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
-func (resource *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (resource *WorkspaceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
+		Blocks: map[string]tfschema.Block{
+			"timeouts": timeouts.BlockAll(ctx),
+		},
 		Attributes: map[string]tfschema.Attribute{
 			"id": tfschema.StringAttribute{
 				Computed: true,
@@ -150,25 +156,29 @@ func (r *WorkspaceResource) logFields(ctx context.Context, data WorkspaceResourc
 }
 
 func (resource *WorkspaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data WorkspaceResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var plan WorkspaceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	ctx = resource.logFields(ctx, data)
-	tflog.Debug(ctx, "creating workspace")
+	createTimeout, diags := plan.Timeouts.Create(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Create the workspace
+	ctx = resource.logFields(ctx, plan)
+	tflog.Debug(ctx, "creating workspace")
 
 	workspace := &sdk.Workspace{
 		Metadata: &sdk.RegionalResourceMetadata{
 			Tenant: resource.tenant,
-			Name:   data.Name.ValueString(),
+			Name:   plan.Name.ValueString(),
 		},
-		Labels:      toStringMap(data.Labels),
-		Annotations: toStringMap(data.Annotations),
-		Extensions:  toStringMap(data.Extensions),
+		Labels:      toStringMap(plan.Labels),
+		Annotations: toStringMap(plan.Annotations),
+		Extensions:  toStringMap(plan.Extensions),
 	}
 
 	workspace, err := resource.client.WorkspaceV1.CreateOrUpdateWorkspace(ctx, workspace)
@@ -182,14 +192,12 @@ func (resource *WorkspaceResource) Create(ctx context.Context, req resource.Crea
 
 	tflog.Debug(ctx, "waiting for workspace to become active")
 
-	// Wait until it is active
-
 	tref := secapi.TenantReference{
 		Tenant: secapi.TenantID(workspace.Metadata.Tenant),
 		Name:   workspace.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(plan.Retry).withTimeout(createTimeout).untilState(sdk.ResourceStateActive)
 
 	workspace, err = resource.client.WorkspaceV1.GetWorkspaceUntilState(ctx, tref, config)
 	if err != nil {
@@ -200,15 +208,16 @@ func (resource *WorkspaceResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	data, diags := workspaceToResourceModel(ctx, workspace)
-	resp.Diagnostics.Append(diags...)
+	state, diags2 := workspaceToResourceModel(ctx, workspace)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Timeouts = plan.Timeouts
 
 	tflog.Info(ctx, "workspace created")
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (resource *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -251,25 +260,29 @@ func (resource *WorkspaceResource) Read(ctx context.Context, req resource.ReadRe
 }
 
 func (resource *WorkspaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data WorkspaceResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var plan WorkspaceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	ctx = resource.logFields(ctx, data)
-	tflog.Debug(ctx, "updating workspace")
+	updateTimeout, diags := plan.Timeouts.Update(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Update the workspace
+	ctx = resource.logFields(ctx, plan)
+	tflog.Debug(ctx, "updating workspace")
 
 	workspace := &sdk.Workspace{
 		Metadata: &sdk.RegionalResourceMetadata{
 			Tenant: resource.tenant,
-			Name:   data.Name.ValueString(),
+			Name:   plan.Name.ValueString(),
 		},
-		Labels:      toStringMap(data.Labels),
-		Annotations: toStringMap(data.Annotations),
-		Extensions:  toStringMap(data.Extensions),
+		Labels:      toStringMap(plan.Labels),
+		Annotations: toStringMap(plan.Annotations),
+		Extensions:  toStringMap(plan.Extensions),
 	}
 
 	workspace, err := resource.client.WorkspaceV1.CreateOrUpdateWorkspace(ctx, workspace)
@@ -283,14 +296,12 @@ func (resource *WorkspaceResource) Update(ctx context.Context, req resource.Upda
 
 	tflog.Debug(ctx, "waiting for workspace to become active")
 
-	// Wait until it is active
-
 	tref := secapi.TenantReference{
 		Tenant: secapi.TenantID(workspace.Metadata.Tenant),
 		Name:   workspace.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).untilState(sdk.ResourceStateActive)
+	config := resource.retry.with(plan.Retry).withTimeout(updateTimeout).untilState(sdk.ResourceStateActive)
 
 	workspace, err = resource.client.WorkspaceV1.GetWorkspaceUntilState(ctx, tref, config)
 	if err != nil {
@@ -301,15 +312,16 @@ func (resource *WorkspaceResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	data, diags := workspaceToResourceModel(ctx, workspace)
-	resp.Diagnostics.Append(diags...)
+	state, diags2 := workspaceToResourceModel(ctx, workspace)
+	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Timeouts = plan.Timeouts
 
 	tflog.Info(ctx, "workspace updated")
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (resource *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -319,10 +331,14 @@ func (resource *WorkspaceResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
+	deleteTimeout, diags := data.Timeouts.Delete(ctx, 10*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	ctx = resource.logFields(ctx, data)
 	tflog.Debug(ctx, "deleting workspace")
-
-	// Delete the workspace
 
 	workspace := &sdk.Workspace{
 		Metadata: &sdk.RegionalResourceMetadata{
@@ -342,14 +358,12 @@ func (resource *WorkspaceResource) Delete(ctx context.Context, req resource.Dele
 
 	tflog.Debug(ctx, "waiting for workspace to be deleted")
 
-	// Wait until it is deleted
-
 	tref := secapi.TenantReference{
 		Tenant: secapi.TenantID(workspace.Metadata.Tenant),
 		Name:   workspace.Metadata.Name,
 	}
 
-	config := resource.retry.with(data.Retry).observer()
+	config := resource.retry.with(data.Retry).withTimeout(deleteTimeout).observer()
 
 	err = resource.client.WorkspaceV1.WatchWorkspaceUntilDeleted(ctx, tref, config)
 	if err != nil {

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"math"
 	"time"
 
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -51,6 +52,15 @@ func (c retryConfig) with(override *RetryModel) retryConfig {
 	}
 	if !override.MaxAttempts.IsNull() && !override.MaxAttempts.IsUnknown() {
 		c.maxAttempts = numberToInt(override.MaxAttempts)
+	}
+	return c
+}
+
+// withTimeout derives MaxAttempts from the given duration divided by the polling interval,
+// overriding any max_attempts set via the retry block. timeout=0 leaves MaxAttempts unchanged.
+func (c retryConfig) withTimeout(timeout time.Duration) retryConfig {
+	if timeout > 0 && c.interval > 0 {
+		c.maxAttempts = int(math.Ceil(float64(timeout) / float64(c.interval)))
 	}
 	return c
 }


### PR DESCRIPTION
## Summary
- Adds standard  blocks to all 11 resource schemas on  via  v0.7.0
-  derives , replacing the coarse  for per-resource tuning
- Per-resource defaults: / → 10 m,  → 15 m, all networking and IAM resources → 5 m
- Updates  with the new polling pattern and a defaults table

## Usage


## Test plan
- [ ]  passes (verified locally)
- [ ]  passes (verified locally)
- [ ] Unit test:  computes correct MaxAttempts from duration/interval
- [ ] Acceptance test: resource with custom timeout completes (or fails with clear error) within the given window

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)