### PR TITLE
GA-39: User guides - import, authentication, troubleshooting

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,0 +1,89 @@
+---
+page_title: "Authentication — seca Provider"
+subcategory: "Guides"
+description: |-
+  How to obtain a bearer token and configure the seca provider for authentication.
+---
+
+# Authentication
+
+The seca provider authenticates to the SECA platform using a **bearer token**. This guide explains how to obtain a token and configure the provider securely.
+
+## Obtaining a Bearer Token
+
+Bearer tokens are issued by the SECA Identity service. Refer to the SECA platform documentation for your tenant to create a service-account token with the appropriate scopes for the resources you intend to manage.
+
+Once you have a token, store it in an environment variable instead of hard-coding it in your Terraform configuration:
+
+```shell
+export SECA_TOKEN="<your-token-here>"
+```
+
+## Minimal Provider Configuration
+
+The minimum required configuration is `token`, `tenant`, `region`, and the `global_providers` block pointing at the control-plane endpoints for your region:
+
+```terraform
+provider "seca" {
+  token  = var.seca_token   # or use SECA_TOKEN env var indirectly via variable
+  tenant = "my-tenant"
+  region = "eu-central-1"
+
+  global_providers = {
+    region_v1 = "https://api.seca.cloud/providers/seca.region"
+  }
+}
+
+variable "seca_token" {
+  type      = string
+  sensitive = true
+}
+```
+
+## Full Provider Configuration
+
+When managing IAM resources (`seca_role`, `seca_role_assignment`) you must also provide the `authorization_v1` endpoint. The optional `retry` block fine-tunes polling behaviour for async API operations:
+
+```terraform
+provider "seca" {
+  token  = var.seca_token
+  tenant = "my-tenant"
+  region = "eu-central-1"
+
+  global_providers = {
+    region_v1        = "https://api.seca.cloud/providers/seca.region"
+    authorization_v1 = "https://api.seca.cloud/providers/seca.authorization"
+  }
+
+  retry = {
+    delay        = 30  # seconds before first status poll
+    interval     = 10  # seconds between subsequent polls
+    max_attempts = 30  # maximum polling attempts (≈ 5 minutes total)
+  }
+}
+```
+
+## Using Environment Variables
+
+To avoid placing credentials in Terraform files (which might be committed to version control), pass the token through a variable that is supplied at runtime:
+
+```shell
+# terraform.tfvars (gitignored) or via -var flag
+TF_VAR_seca_token="<your-token-here>" terraform apply
+```
+
+Alternatively, use a secrets manager (Vault, AWS Secrets Manager, etc.) to inject `var.seca_token` at plan time.
+
+## Token Scopes
+
+The token must have sufficient permissions for the SECA API calls your configuration will make:
+
+| Resource type | Required API scope |
+|---|---|
+| `seca_workspace` | `WorkspaceV1` write |
+| `seca_network`, `seca_subnet`, `seca_nic`, etc. | `NetworkV1` write |
+| `seca_block_storage`, `seca_image` | `StorageV1` write |
+| `seca_instance` | `ComputeV1` write |
+| `seca_role`, `seca_role_assignment` | `AuthorizationV1` admin |
+
+Data sources require the corresponding read scope only.

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -1,0 +1,149 @@
+---
+page_title: "Importing Resources — seca Provider"
+subcategory: "Guides"
+description: |-
+  How to import existing SECA resources into Terraform state using terraform import.
+---
+
+# Importing Existing Resources
+
+If you have resources already provisioned on the SECA platform that you want to bring under Terraform management, use `terraform import`. This guide shows the import identifier format for each resource type.
+
+## Import ID Format
+
+Resources are identified in one of two ways depending on their scope:
+
+| Scope | Format | Example |
+|---|---|---|
+| Tenant-scoped | `<name>` | `my-workspace` |
+| Workspace-scoped | `<workspace_id>/<name>` | `ws-abc123/my-network` |
+
+The import command syntax is:
+```shell
+terraform import <resource_address> <import_id>
+```
+
+## Resource Import Examples
+
+### seca_workspace
+
+Workspaces are tenant-scoped; use the workspace name:
+
+```shell
+terraform import seca_workspace.main my-workspace
+```
+
+```terraform
+resource "seca_workspace" "main" {
+  name = "my-workspace"
+}
+```
+
+### seca_image
+
+Images are tenant-scoped; use the image name:
+
+```shell
+terraform import seca_image.base ubuntu-22-amd64
+```
+
+```terraform
+resource "seca_image" "base" {
+  name             = "ubuntu-22-amd64"
+  block_storage_id = data.seca_block_storage.source.id
+  cpu_architecture = "amd64"
+  initializer      = "cloudinit-22"
+  boot             = "UEFI"
+}
+```
+
+### seca_block_storage
+
+Block storage volumes are workspace-scoped:
+
+```shell
+terraform import seca_block_storage.data "ws-abc123/my-volume"
+```
+
+```terraform
+resource "seca_block_storage" "data" {
+  name         = "my-volume"
+  workspace_id = seca_workspace.main.id
+  size_gb      = 100
+  sku_id       = data.seca_storage_sku.fast.id
+}
+```
+
+### seca_network
+
+Networks are workspace-scoped:
+
+```shell
+terraform import seca_network.vpc "ws-abc123/my-network"
+```
+
+```terraform
+resource "seca_network" "vpc" {
+  name         = "my-network"
+  workspace_id = seca_workspace.main.id
+  sku_id       = data.seca_network_sku.default.id
+  cidr = {
+    ipv4 = "10.100.0.0/16"
+  }
+}
+```
+
+### seca_nic
+
+NICs are workspace-scoped:
+
+```shell
+terraform import seca_nic.primary "ws-abc123/my-nic"
+```
+
+### seca_instance
+
+Instances are workspace-scoped:
+
+```shell
+terraform import seca_instance.web "ws-abc123/my-instance"
+```
+
+```terraform
+resource "seca_instance" "web" {
+  name           = "my-instance"
+  workspace_id   = seca_workspace.main.id
+  sku_id         = data.seca_instance_sku.small.id
+  primary_nic_id = seca_nic.primary.id
+  zone           = "a"
+  boot_volume = {
+    device_id = seca_block_storage.os.id
+  }
+}
+```
+
+### seca_role
+
+Roles are tenant-scoped:
+
+```shell
+terraform import seca_role.network_reader network-reader
+```
+
+### seca_role_assignment
+
+Role assignments are tenant-scoped:
+
+```shell
+terraform import seca_role_assignment.my_assign my-assignment
+```
+
+## Handling Drift After Import
+
+After importing, run `terraform plan` to detect any differences between the imported state and your Terraform configuration. Common sources of drift:
+
+- **Computed fields**: Fields like `tenant`, `region`, `created_at` are set by the API and should be left out of your configuration or declared as `Computed`.
+- **Optional fields with defaults**: If you omit `labels`, `annotations`, or `extensions` in your configuration but the resource has them, Terraform will plan to remove them. Add them to your config to avoid unintended changes.
+- **Immutable fields**: Some fields (e.g. `cidr` on `seca_network`, `sku_id` on `seca_block_storage`) cannot be changed after creation. If they differ, Terraform will plan a destroy-and-recreate.
+
+Always review the plan carefully after import before applying.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,125 @@
+---
+page_title: "Troubleshooting — seca Provider"
+subcategory: "Guides"
+description: |-
+  Common issues and solutions when working with the seca Terraform provider.
+---
+
+# Troubleshooting
+
+This guide covers the most common problems encountered when using the seca provider and how to resolve them.
+
+## Enabling Debug Logging
+
+Set `TF_LOG=DEBUG` (or `TF_LOG=TRACE` for maximum verbosity) before running Terraform to capture detailed provider logs:
+
+```shell
+TF_LOG=DEBUG TF_LOG_PATH=./terraform.log terraform apply
+```
+
+The provider uses structured logging via `tflog`. Look for log lines prefixed with the resource type and operation to trace exactly where a failure occurred.
+
+## Resources Stuck in "Creating" or "Updating" State
+
+The SECA API is eventually consistent — `terraform apply` polls until a resource reaches `Active` state. If a resource stays in `Creating` or `Updating` for a long time, the provider will return a polling timeout error.
+
+### Default Polling Limits
+
+| Resource | Default create/update timeout |
+|---|---|
+| `seca_workspace` | 10 minutes |
+| `seca_image` | 15 minutes |
+| `seca_block_storage` | 10 minutes |
+| `seca_network`, `seca_subnet`, `seca_nic`, etc. | 5 minutes |
+| `seca_instance` | 20 minutes |
+
+### Extending Timeouts
+
+If your environment is slower than the defaults (e.g., large image uploads, heavily loaded control plane), increase the timeout via the per-resource `timeouts` block:
+
+```terraform
+resource "seca_image" "large" {
+  name             = "large-image"
+  block_storage_id = seca_block_storage.source.id
+  cpu_architecture = "amd64"
+  initializer      = "cloudinit-22"
+  boot             = "UEFI"
+
+  timeouts {
+    create = "30m"
+    delete = "20m"
+  }
+}
+
+resource "seca_instance" "heavy" {
+  name           = "heavy-instance"
+  workspace_id   = seca_workspace.main.id
+  sku_id         = data.seca_instance_sku.xlarge.id
+  primary_nic_id = seca_nic.primary.id
+  zone           = "a"
+  boot_volume    = { device_id = seca_block_storage.os.id }
+
+  timeouts {
+    create = "40m"
+    delete = "30m"
+  }
+}
+```
+
+### Fine-Tuning Polling Interval
+
+For resources that provision quickly, reduce the polling interval to get faster feedback:
+
+```terraform
+provider "seca" {
+  # ...
+  retry = {
+    delay        = 5   # seconds before first poll
+    interval     = 5   # seconds between polls
+    max_attempts = 60  # stop after 60 × 5s = 5 minutes
+  }
+}
+```
+
+## Eventual Consistency: Resources Not Found After Creation
+
+Occasionally, reading a resource immediately after creation returns `404 Not Found` because the SECA API has not yet propagated the change. The provider handles this transparently by polling `GetXxxUntilState()`. If you see a `404` error in plan output (not during apply), re-run `terraform plan` — the transient state usually resolves within seconds.
+
+## Common API Errors
+
+### `401 Unauthorized`
+
+Your bearer token has expired or is invalid. Re-obtain a fresh token and update your `seca_token` variable.
+
+### `403 Forbidden`
+
+The token has insufficient scopes for the operation. Check the required API scope for the resource you are managing (see the [Authentication guide](authentication.md)).
+
+### `409 Conflict`
+
+A resource with the same name already exists. Either import the existing resource (`terraform import`) or choose a different name.
+
+### `422 Unprocessable Entity`
+
+The API rejected the request due to invalid field values (e.g., a CIDR block that overlaps with an existing network). Check the error message for the specific field and correct it in your configuration.
+
+### `503 Service Unavailable`
+
+The SECA control plane is temporarily unavailable. Wait a few minutes and retry. Consider increasing `retry.interval` and `retry.max_attempts` if this happens frequently in your environment.
+
+## Terraform State Drift
+
+If resources are modified outside of Terraform (e.g., via the SECA portal or API directly), the next `terraform plan` will show unexpected differences. Run `terraform refresh` to synchronise state with the current API state, then review the plan before applying.
+
+## Destroying Resources That Are in Use
+
+Attempting to destroy a resource that other resources depend on (e.g., deleting a workspace while instances are still running) will fail with an API error. Destroy dependent resources first, or use `depends_on` / resource ordering to control the destroy order.
+
+## Getting Help
+
+If you encounter an issue not covered here, please open a bug report at the provider repository including:
+
+1. The Terraform version (`terraform version`)
+2. The provider version
+3. The relevant Terraform configuration (redact sensitive values)
+4. The full error message and debug log excerpt (`TF_LOG=DEBUG`)

--- a/templates/guides/authentication.md.tmpl
+++ b/templates/guides/authentication.md.tmpl
@@ -1,0 +1,89 @@
+---
+page_title: "Authentication — seca Provider"
+subcategory: "Guides"
+description: |-
+  How to obtain a bearer token and configure the seca provider for authentication.
+---
+
+# Authentication
+
+The seca provider authenticates to the SECA platform using a **bearer token**. This guide explains how to obtain a token and configure the provider securely.
+
+## Obtaining a Bearer Token
+
+Bearer tokens are issued by the SECA Identity service. Refer to the SECA platform documentation for your tenant to create a service-account token with the appropriate scopes for the resources you intend to manage.
+
+Once you have a token, store it in an environment variable instead of hard-coding it in your Terraform configuration:
+
+```shell
+export SECA_TOKEN="<your-token-here>"
+```
+
+## Minimal Provider Configuration
+
+The minimum required configuration is `token`, `tenant`, `region`, and the `global_providers` block pointing at the control-plane endpoints for your region:
+
+```terraform
+provider "seca" {
+  token  = var.seca_token   # or use SECA_TOKEN env var indirectly via variable
+  tenant = "my-tenant"
+  region = "eu-central-1"
+
+  global_providers = {
+    region_v1 = "https://api.seca.cloud/providers/seca.region"
+  }
+}
+
+variable "seca_token" {
+  type      = string
+  sensitive = true
+}
+```
+
+## Full Provider Configuration
+
+When managing IAM resources (`seca_role`, `seca_role_assignment`) you must also provide the `authorization_v1` endpoint. The optional `retry` block fine-tunes polling behaviour for async API operations:
+
+```terraform
+provider "seca" {
+  token  = var.seca_token
+  tenant = "my-tenant"
+  region = "eu-central-1"
+
+  global_providers = {
+    region_v1        = "https://api.seca.cloud/providers/seca.region"
+    authorization_v1 = "https://api.seca.cloud/providers/seca.authorization"
+  }
+
+  retry = {
+    delay        = 30  # seconds before first status poll
+    interval     = 10  # seconds between subsequent polls
+    max_attempts = 30  # maximum polling attempts (≈ 5 minutes total)
+  }
+}
+```
+
+## Using Environment Variables
+
+To avoid placing credentials in Terraform files (which might be committed to version control), pass the token through a variable that is supplied at runtime:
+
+```shell
+# terraform.tfvars (gitignored) or via -var flag
+TF_VAR_seca_token="<your-token-here>" terraform apply
+```
+
+Alternatively, use a secrets manager (Vault, AWS Secrets Manager, etc.) to inject `var.seca_token` at plan time.
+
+## Token Scopes
+
+The token must have sufficient permissions for the SECA API calls your configuration will make:
+
+| Resource type | Required API scope |
+|---|---|
+| `seca_workspace` | `WorkspaceV1` write |
+| `seca_network`, `seca_subnet`, `seca_nic`, etc. | `NetworkV1` write |
+| `seca_block_storage`, `seca_image` | `StorageV1` write |
+| `seca_instance` | `ComputeV1` write |
+| `seca_role`, `seca_role_assignment` | `AuthorizationV1` admin |
+
+Data sources require the corresponding read scope only.

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -1,0 +1,149 @@
+---
+page_title: "Importing Resources — seca Provider"
+subcategory: "Guides"
+description: |-
+  How to import existing SECA resources into Terraform state using terraform import.
+---
+
+# Importing Existing Resources
+
+If you have resources already provisioned on the SECA platform that you want to bring under Terraform management, use `terraform import`. This guide shows the import identifier format for each resource type.
+
+## Import ID Format
+
+Resources are identified in one of two ways depending on their scope:
+
+| Scope | Format | Example |
+|---|---|---|
+| Tenant-scoped | `<name>` | `my-workspace` |
+| Workspace-scoped | `<workspace_id>/<name>` | `ws-abc123/my-network` |
+
+The import command syntax is:
+```shell
+terraform import <resource_address> <import_id>
+```
+
+## Resource Import Examples
+
+### seca_workspace
+
+Workspaces are tenant-scoped; use the workspace name:
+
+```shell
+terraform import seca_workspace.main my-workspace
+```
+
+```terraform
+resource "seca_workspace" "main" {
+  name = "my-workspace"
+}
+```
+
+### seca_image
+
+Images are tenant-scoped; use the image name:
+
+```shell
+terraform import seca_image.base ubuntu-22-amd64
+```
+
+```terraform
+resource "seca_image" "base" {
+  name             = "ubuntu-22-amd64"
+  block_storage_id = data.seca_block_storage.source.id
+  cpu_architecture = "amd64"
+  initializer      = "cloudinit-22"
+  boot             = "UEFI"
+}
+```
+
+### seca_block_storage
+
+Block storage volumes are workspace-scoped:
+
+```shell
+terraform import seca_block_storage.data "ws-abc123/my-volume"
+```
+
+```terraform
+resource "seca_block_storage" "data" {
+  name         = "my-volume"
+  workspace_id = seca_workspace.main.id
+  size_gb      = 100
+  sku_id       = data.seca_storage_sku.fast.id
+}
+```
+
+### seca_network
+
+Networks are workspace-scoped:
+
+```shell
+terraform import seca_network.vpc "ws-abc123/my-network"
+```
+
+```terraform
+resource "seca_network" "vpc" {
+  name         = "my-network"
+  workspace_id = seca_workspace.main.id
+  sku_id       = data.seca_network_sku.default.id
+  cidr = {
+    ipv4 = "10.100.0.0/16"
+  }
+}
+```
+
+### seca_nic
+
+NICs are workspace-scoped:
+
+```shell
+terraform import seca_nic.primary "ws-abc123/my-nic"
+```
+
+### seca_instance
+
+Instances are workspace-scoped:
+
+```shell
+terraform import seca_instance.web "ws-abc123/my-instance"
+```
+
+```terraform
+resource "seca_instance" "web" {
+  name           = "my-instance"
+  workspace_id   = seca_workspace.main.id
+  sku_id         = data.seca_instance_sku.small.id
+  primary_nic_id = seca_nic.primary.id
+  zone           = "a"
+  boot_volume = {
+    device_id = seca_block_storage.os.id
+  }
+}
+```
+
+### seca_role
+
+Roles are tenant-scoped:
+
+```shell
+terraform import seca_role.network_reader network-reader
+```
+
+### seca_role_assignment
+
+Role assignments are tenant-scoped:
+
+```shell
+terraform import seca_role_assignment.my_assign my-assignment
+```
+
+## Handling Drift After Import
+
+After importing, run `terraform plan` to detect any differences between the imported state and your Terraform configuration. Common sources of drift:
+
+- **Computed fields**: Fields like `tenant`, `region`, `created_at` are set by the API and should be left out of your configuration or declared as `Computed`.
+- **Optional fields with defaults**: If you omit `labels`, `annotations`, or `extensions` in your configuration but the resource has them, Terraform will plan to remove them. Add them to your config to avoid unintended changes.
+- **Immutable fields**: Some fields (e.g. `cidr` on `seca_network`, `sku_id` on `seca_block_storage`) cannot be changed after creation. If they differ, Terraform will plan a destroy-and-recreate.
+
+Always review the plan carefully after import before applying.

--- a/templates/guides/troubleshooting.md.tmpl
+++ b/templates/guides/troubleshooting.md.tmpl
@@ -1,0 +1,125 @@
+---
+page_title: "Troubleshooting — seca Provider"
+subcategory: "Guides"
+description: |-
+  Common issues and solutions when working with the seca Terraform provider.
+---
+
+# Troubleshooting
+
+This guide covers the most common problems encountered when using the seca provider and how to resolve them.
+
+## Enabling Debug Logging
+
+Set `TF_LOG=DEBUG` (or `TF_LOG=TRACE` for maximum verbosity) before running Terraform to capture detailed provider logs:
+
+```shell
+TF_LOG=DEBUG TF_LOG_PATH=./terraform.log terraform apply
+```
+
+The provider uses structured logging via `tflog`. Look for log lines prefixed with the resource type and operation to trace exactly where a failure occurred.
+
+## Resources Stuck in "Creating" or "Updating" State
+
+The SECA API is eventually consistent — `terraform apply` polls until a resource reaches `Active` state. If a resource stays in `Creating` or `Updating` for a long time, the provider will return a polling timeout error.
+
+### Default Polling Limits
+
+| Resource | Default create/update timeout |
+|---|---|
+| `seca_workspace` | 10 minutes |
+| `seca_image` | 15 minutes |
+| `seca_block_storage` | 10 minutes |
+| `seca_network`, `seca_subnet`, `seca_nic`, etc. | 5 minutes |
+| `seca_instance` | 20 minutes |
+
+### Extending Timeouts
+
+If your environment is slower than the defaults (e.g., large image uploads, heavily loaded control plane), increase the timeout via the per-resource `timeouts` block:
+
+```terraform
+resource "seca_image" "large" {
+  name             = "large-image"
+  block_storage_id = seca_block_storage.source.id
+  cpu_architecture = "amd64"
+  initializer      = "cloudinit-22"
+  boot             = "UEFI"
+
+  timeouts {
+    create = "30m"
+    delete = "20m"
+  }
+}
+
+resource "seca_instance" "heavy" {
+  name           = "heavy-instance"
+  workspace_id   = seca_workspace.main.id
+  sku_id         = data.seca_instance_sku.xlarge.id
+  primary_nic_id = seca_nic.primary.id
+  zone           = "a"
+  boot_volume    = { device_id = seca_block_storage.os.id }
+
+  timeouts {
+    create = "40m"
+    delete = "30m"
+  }
+}
+```
+
+### Fine-Tuning Polling Interval
+
+For resources that provision quickly, reduce the polling interval to get faster feedback:
+
+```terraform
+provider "seca" {
+  # ...
+  retry = {
+    delay        = 5   # seconds before first poll
+    interval     = 5   # seconds between polls
+    max_attempts = 60  # stop after 60 × 5s = 5 minutes
+  }
+}
+```
+
+## Eventual Consistency: Resources Not Found After Creation
+
+Occasionally, reading a resource immediately after creation returns `404 Not Found` because the SECA API has not yet propagated the change. The provider handles this transparently by polling `GetXxxUntilState()`. If you see a `404` error in plan output (not during apply), re-run `terraform plan` — the transient state usually resolves within seconds.
+
+## Common API Errors
+
+### `401 Unauthorized`
+
+Your bearer token has expired or is invalid. Re-obtain a fresh token and update your `seca_token` variable.
+
+### `403 Forbidden`
+
+The token has insufficient scopes for the operation. Check the required API scope for the resource you are managing (see the [Authentication guide](authentication.md)).
+
+### `409 Conflict`
+
+A resource with the same name already exists. Either import the existing resource (`terraform import`) or choose a different name.
+
+### `422 Unprocessable Entity`
+
+The API rejected the request due to invalid field values (e.g., a CIDR block that overlaps with an existing network). Check the error message for the specific field and correct it in your configuration.
+
+### `503 Service Unavailable`
+
+The SECA control plane is temporarily unavailable. Wait a few minutes and retry. Consider increasing `retry.interval` and `retry.max_attempts` if this happens frequently in your environment.
+
+## Terraform State Drift
+
+If resources are modified outside of Terraform (e.g., via the SECA portal or API directly), the next `terraform plan` will show unexpected differences. Run `terraform refresh` to synchronise state with the current API state, then review the plan before applying.
+
+## Destroying Resources That Are in Use
+
+Attempting to destroy a resource that other resources depend on (e.g., deleting a workspace while instances are still running) will fail with an API error. Destroy dependent resources first, or use `depends_on` / resource ordering to control the destroy order.
+
+## Getting Help
+
+If you encounter an issue not covered here, please open a bug report at the provider repository including:
+
+1. The Terraform version (`terraform version`)
+2. The provider version
+3. The relevant Terraform configuration (redact sensitive values)
+4. The full error message and debug log excerpt (`TF_LOG=DEBUG`)


### PR DESCRIPTION
## Summary
Adds three guides under docs/guides/: authentication, import, troubleshooting. Closes #51.
