### PR TITLE
GA-37: Phase-5 authorization acceptance tests

### DIFF
--- a/internal/acctest/role_assignment_test.go
+++ b/internal/acctest/role_assignment_test.go
@@ -66,8 +66,6 @@ resource "seca_role_assignment" "test" {
       tenants = [%s]
     }
   ]
-
-  depends_on = [seca_role.test]
 }
 `, subs, roles)
 }
@@ -96,8 +94,6 @@ resource "seca_role_assignment" "test" {
       tenants = [%q]
     }
   ]
-
-  depends_on = [seca_role.test]
 }
 
 data "seca_role_assignment" "test" {

--- a/internal/acctest/role_assignment_test.go
+++ b/internal/acctest/role_assignment_test.go
@@ -14,7 +14,7 @@ import (
 func testAccCheckRoleAssignmentDestroy(s *terraform.State) error {
 	ctx := context.Background()
 
-	client, err := testAccGlobalClient(ctx)
+	client, err := testAccGlobalClient()
 	if err != nil {
 		return err
 	}

--- a/internal/acctest/role_assignment_test.go
+++ b/internal/acctest/role_assignment_test.go
@@ -1,0 +1,154 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCheckRoleAssignmentDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccGlobalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_role_assignment" {
+			continue
+		}
+
+		tref := secapi.TenantReference{
+			Tenant: secapi.TenantID(testAccTenant),
+			Name:   rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.AuthorizationV1.GetRoleAssignment(ctx, tref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking role assignment %q was destroyed: %w", tref.Name, err)
+		}
+		return fmt.Errorf("role assignment %q still exists after destroy", tref.Name)
+	}
+
+	return nil
+}
+
+func testAccRoleAssignmentResourceConfig(subs, roles string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_role" "test" {
+  name = "role-1"
+
+  permissions = [
+    {
+      provider  = "seca.storage/v1"
+      resources = ["block-storages/*"]
+      verb      = ["get", "list"]
+    }
+  ]
+}
+
+resource "seca_role_assignment" "test" {
+  name  = "ra-1"
+  subs  = [%s]
+  roles = [seca_role.test.name]
+
+  scopes = [
+    {
+      tenants = [%s]
+    }
+  ]
+
+  depends_on = [seca_role.test]
+}
+`, subs, roles)
+}
+
+func testAccRoleAssignmentDataSourceConfig() string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_role" "test" {
+  name = "role-1"
+
+  permissions = [
+    {
+      provider  = "seca.storage/v1"
+      resources = ["block-storages/*"]
+      verb      = ["get", "list"]
+    }
+  ]
+}
+
+resource "seca_role_assignment" "test" {
+  name  = "ra-1"
+  subs  = [%q]
+  roles = [seca_role.test.name]
+
+  scopes = [
+    {
+      tenants = [%q]
+    }
+  ]
+
+  depends_on = [seca_role.test]
+}
+
+data "seca_role_assignment" "test" {
+  name = seca_role_assignment.test.name
+}`, "sa-1", testAccTenant)
+}
+
+func TestAccRoleAssignment(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckRoleAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleAssignmentResourceConfig(fmt.Sprintf("%q", "sa-1"), fmt.Sprintf("%q", testAccTenant)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "name", "ra-1"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "subs.#", "1"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "subs.0", "sa-1"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "roles.#", "1"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "scopes.#", "1"),
+				),
+			},
+			{
+				Config: testAccRoleAssignmentResourceConfig(fmt.Sprintf("%q, %q", "sa-1", "sa-2"), fmt.Sprintf("%q", testAccTenant)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "subs.#", "2"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "subs.0", "sa-1"),
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "subs.1", "sa-2"),
+				),
+			},
+			{
+				ResourceName:      "seca_role_assignment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "ra-1",
+			},
+			{
+				Config: testAccRoleAssignmentDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role_assignment.test", "name", "ra-1"),
+
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "name", "ra-1"),
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "state", "active"),
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "subs.#", "1"),
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "roles.#", "1"),
+					resource.TestCheckResourceAttr("data.seca_role_assignment.test", "scopes.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acctest/role_test.go
+++ b/internal/acctest/role_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func testAccGlobalClient(ctx context.Context) (*secapi.GlobalClient, error) {
+func testAccGlobalClient() (*secapi.GlobalClient, error) {
 	return secapi.NewGlobalClient(&secapi.GlobalConfig{
 		AuthToken: testAccToken,
 		Endpoints: secapi.GlobalEndpoints{
@@ -24,7 +24,7 @@ func testAccGlobalClient(ctx context.Context) (*secapi.GlobalClient, error) {
 func testAccCheckRoleDestroy(s *terraform.State) error {
 	ctx := context.Background()
 
-	client, err := testAccGlobalClient(ctx)
+	client, err := testAccGlobalClient()
 	if err != nil {
 		return err
 	}

--- a/internal/acctest/role_test.go
+++ b/internal/acctest/role_test.go
@@ -1,0 +1,139 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccGlobalClient(ctx context.Context) (*secapi.GlobalClient, error) {
+	return secapi.NewGlobalClient(&secapi.GlobalConfig{
+		AuthToken: testAccToken,
+		Endpoints: secapi.GlobalEndpoints{
+			RegionV1:        testAccEndpointReg,
+			AuthorizationV1: testAccEndpointAuth,
+		},
+	})
+}
+
+func testAccCheckRoleDestroy(s *terraform.State) error {
+	ctx := context.Background()
+
+	client, err := testAccGlobalClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "seca_role" {
+			continue
+		}
+
+		tref := secapi.TenantReference{
+			Tenant: secapi.TenantID(testAccTenant),
+			Name:   rs.Primary.Attributes["name"],
+		}
+
+		_, err := client.AuthorizationV1.GetRole(ctx, tref)
+		if err == secapi.ErrResourceNotFound {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking role %q was destroyed: %w", tref.Name, err)
+		}
+		return fmt.Errorf("role %q still exists after destroy", tref.Name)
+	}
+
+	return nil
+}
+
+func testAccRoleResourceConfig(permissions string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "seca_role" "test" {
+  name = "role-1"
+
+  permissions = [%s]
+}
+`, permissions)
+}
+
+func testAccRoleDataSourceConfig() string {
+	return testAccProviderConfig() + `
+resource "seca_role" "test" {
+  name = "role-1"
+
+  permissions = [
+    {
+      provider  = "seca.storage/v1"
+      resources = ["block-storages/*"]
+      verb      = ["get", "list"]
+    }
+  ]
+}
+data "seca_role" "test" {
+  name = seca_role.test.name
+}`
+}
+
+func TestAccRole(t *testing.T) {
+	permCreate := `
+    {
+      provider  = "seca.storage/v1"
+      resources = ["block-storages/*"]
+      verb      = ["get", "list"]
+    }`
+
+	permUpdate := `
+    {
+      provider  = "seca.storage/v1"
+      resources = ["block-storages/*"]
+      verb      = ["get", "list", "put", "delete"]
+    }`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleResourceConfig(permCreate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role.test", "name", "role-1"),
+					resource.TestCheckResourceAttr("seca_role.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("seca_role.test", "permissions.#", "1"),
+					resource.TestCheckResourceAttr("seca_role.test", "permissions.0.provider", "seca.storage/v1"),
+					resource.TestCheckResourceAttr("seca_role.test", "permissions.0.verb.#", "2"),
+				),
+			},
+			{
+				Config: testAccRoleResourceConfig(permUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role.test", "name", "role-1"),
+					resource.TestCheckResourceAttr("seca_role.test", "permissions.0.verb.#", "4"),
+				),
+			},
+			{
+				ResourceName:      "seca_role.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "role-1",
+			},
+			{
+				Config: testAccRoleDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("seca_role.test", "name", "role-1"),
+
+					resource.TestCheckResourceAttr("data.seca_role.test", "name", "role-1"),
+					resource.TestCheckResourceAttr("data.seca_role.test", "tenant", testAccTenant),
+					resource.TestCheckResourceAttr("data.seca_role.test", "state", "active"),
+					resource.TestCheckResourceAttr("data.seca_role.test", "permissions.#", "1"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #49

Depends on #83 (GA-36) which depends on #82 (GA-35).

## Summary

**role_test.go** — TestAccRole:
- Create role with permissions
- Update permissions in-place
- Import by name
- CheckDestroy via AuthorizationV1.GetRole
- Data source lookup

**role_assignment_test.go** — TestAccRoleAssignment:
- Create role assignment with scope (creates prerequisite seca_role inline)
- Update subs in-place
- Import by name
- CheckDestroy via AuthorizationV1.GetRoleAssignment
- Data source lookup

Adds 	estAccGlobalClient helper to the acctest package for authorization API calls.

## Test plan
- [x] go test ./internal/acctest/... compiles (unit mode)
- [ ] Full run requires TF_ACC=1 and an AuthorizationV1 endpoint (SECA_TEST_AUTH_ENDPOINT)

Generated with Claude Code