### PR TITLE
GA-41: Negative acceptance tests - invalid SKU and missing workspace

### DIFF
--- a/internal/acctest/negative_test.go
+++ b/internal/acctest/negative_test.go
@@ -1,0 +1,67 @@
+package acctest
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// testAccBlockStorageInvalidSKUConfig returns a config that attempts to create
+// block storage with a non-existent SKU.
+func testAccBlockStorageInvalidSKUConfig() string {
+	return testAccProviderConfig() + `
+resource "seca_workspace" "test" {
+  name = "workspace-neg-1"
+}
+resource "seca_block_storage" "invalid_sku" {
+  name         = "bs-invalid-sku"
+  workspace_id = seca_workspace.test.name
+
+  size_gb = 10
+  sku_id  = "storage-skus/DOES-NOT-EXIST-XYZ"
+}`
+}
+
+// testAccBlockStorageMissingWorkspaceConfig returns a config that attempts to
+// create block storage referencing a workspace that does not exist.
+func testAccBlockStorageMissingWorkspaceConfig() string {
+	return testAccProviderConfig() + `
+resource "seca_block_storage" "missing_ws" {
+  name         = "bs-missing-ws"
+  workspace_id = "workspace-does-not-exist"
+
+  size_gb = 10
+  sku_id  = "storage-skus/RD500"
+}`
+}
+
+// TestAccBlockStorage_InvalidSKU verifies that a non-existent SKU produces
+// a clear error diagnostic rather than a panic or silent failure.
+func TestAccBlockStorage_InvalidSKU(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBlockStorageInvalidSKUConfig(),
+				ExpectError: regexp.MustCompile(`Error creating block storage`),
+			},
+		},
+	})
+}
+
+// TestAccBlockStorage_MissingWorkspace verifies that referencing a
+// non-existent workspace produces a clear error diagnostic.
+func TestAccBlockStorage_MissingWorkspace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBlockStorageMissingWorkspaceConfig(),
+				ExpectError: regexp.MustCompile(`Error creating block storage`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #53

Independent of the role-assignment PRs, targets main directly.

Adds negative_test.go with two apply-time error cases for seca_block_storage:
- TestAccBlockStorage_InvalidSKU: non-existent sku_id, expects Error creating block storage
- TestAccBlockStorage_MissingWorkspace: non-existent workspace_id, expects Error creating block storage

Plan-time negative tests for CIDR, port range, and IP version are deferred until GA-40 validators land on main.

Test plan:
- go test ./internal/acctest/... compiles
- Full run requires TF_ACC=1 and a live SECA cluster

Generated with Claude Code