### PR TITLE
GA-37: Phase-5 authorization acceptance tests

### DIFF
--- a/internal/acctest/role_assignment_test.go
+++ b/internal/acctest/role_assignment_test.go
@@ -66,6 +66,18 @@ resource "seca_role_assignment" "test" {
       tenants = [%s]
     }
   ]
+
+  retry = {
+    delay        = 10
+    interval     = 10
+    max_attempts = 3
+  }
+  timeouts {
+    create = "1m"
+    update = "1m"
+    read   = "30s"
+    delete = "1m"
+  }
 }
 `, subs, roles)
 }
@@ -94,6 +106,18 @@ resource "seca_role_assignment" "test" {
       tenants = [%q]
     }
   ]
+
+  retry = {
+    delay        = 10
+    interval     = 10
+    max_attempts = 3
+  }
+  timeouts {
+    create = "1m"
+    update = "1m"
+    read   = "30s"
+    delete = "1m"
+  }
 }
 
 data "seca_role_assignment" "test" {
@@ -127,10 +151,11 @@ func TestAccRoleAssignment(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "seca_role_assignment.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     "ra-1",
+				ResourceName:            "seca_role_assignment.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           "ra-1",
+				ImportStateVerifyIgnore: []string{"retry"},
 			},
 			{
 				Config: testAccRoleAssignmentDataSourceConfig(),

--- a/internal/acctest/role_test.go
+++ b/internal/acctest/role_test.go
@@ -58,6 +58,18 @@ resource "seca_role" "test" {
   name = "role-1"
 
   permissions = [%s]
+
+  retry = {
+    delay        = 10
+    interval     = 10
+    max_attempts = 3
+  }
+  timeouts {
+    create = "1m"
+    update = "1m"
+    read   = "30s"
+    delete = "1m"
+  }
 }
 `, permissions)
 }
@@ -74,6 +86,18 @@ resource "seca_role" "test" {
       verb      = ["get", "list"]
     }
   ]
+
+  retry = {
+    delay        = 10
+    interval     = 10
+    max_attempts = 3
+  }
+  timeouts {
+    create = "1m"
+    update = "1m"
+    read   = "30s"
+    delete = "1m"
+  }
 }
 data "seca_role" "test" {
   name = seca_role.test.name
@@ -118,10 +142,11 @@ func TestAccRole(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "seca_role.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     "role-1",
+				ResourceName:            "seca_role.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           "role-1",
+				ImportStateVerifyIgnore: []string{"retry"},
 			},
 			{
 				Config: testAccRoleDataSourceConfig(),


### PR DESCRIPTION
Closes #49

Depends on #87 (GA-36 data source) — merge that first so `data "seca_role_assignment"` is registered in the provider.

## Summary

- `internal/acctest/role_test.go` — `TestAccRole`: create with permissions, update permissions in-place, import by name, CheckDestroy via `AuthorizationV1.GetRole`, data source lookup.
- `internal/acctest/role_assignment_test.go` — `TestAccRoleAssignment`: create assignment (with inline role), update subs in-place, import by name, CheckDestroy via `AuthorizationV1.GetRoleAssignment`, data source lookup.
- `testAccGlobalClient` helper added (auth-only global client for CheckDestroy).
- `depends_on` removed from Terraform configs: implicit dependency via `roles = [seca_role.test.name]` is sufficient (consistent with all other acctests).

## Test plan
- [ ] Full run requires `TF_ACC=1` and a `SECA_TEST_AUTH_ENDPOINT` with admin auth token
- [x] `go build ./...` passes

Generated with Claude Code