### PR TITLE
GA-40/GA-41: Plan-time validators and negative acceptance tests

### DIFF
--- a/internal/provider/provider_acc_test.go
+++ b/internal/provider/provider_acc_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// testAccProtoV6ProviderFactories is used by acceptance tests that call
+// resource.Test() (requires TF_ACC=1).
+var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"seca": providerserver.NewProtocol6WithError(New("test")()),
+}
+
+// testAccPreCheck skips the test when required env vars are absent.
+func testAccPreCheck(t *testing.T) {
+	t.Helper()
+	for _, env := range []string{"SECA_TOKEN", "SECA_TENANT", "SECA_REGION", "SECA_REGION_V1_URL"} {
+		if os.Getenv(env) == "" {
+			t.Skipf("%s environment variable not set; skipping acceptance test", env)
+		}
+	}
+}
+
+// testAccProviderConfig returns a provider block using values from environment
+// variables; used by apply-time acceptance tests.
+func testAccProviderConfig() string {
+	return fmt.Sprintf(`
+provider "seca" {
+  token  = %q
+  tenant = %q
+  region = %q
+  global_providers = {
+    region_v1        = %q
+    authorization_v1 = %q
+  }
+}
+`,
+		os.Getenv("SECA_TOKEN"),
+		os.Getenv("SECA_TENANT"),
+		os.Getenv("SECA_REGION"),
+		os.Getenv("SECA_REGION_V1_URL"),
+		os.Getenv("SECA_AUTH_V1_URL"),
+	)
+}
+
+// testUnitProviderConfig returns a provider block with dummy values for use in
+// unit-style acceptance tests (resource.UnitTest) that only exercise plan-time
+// validation and never reach the API.
+const testUnitProviderConfig = `
+provider "seca" {
+  token  = "test-token"
+  tenant = "test-tenant"
+  region = "test-region"
+  global_providers = {
+    region_v1 = "http://localhost:19999"
+  }
+}
+`

--- a/internal/provider/resource_negative_test.go
+++ b/internal/provider/resource_negative_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// ---------------------------------------------------------------------------
+// Plan-time validation tests (resource.UnitTest — no TF_ACC required)
+// ---------------------------------------------------------------------------
+
+// TestAccNetwork_InvalidCIDR verifies that an invalid IPv4 CIDR on seca_network
+// produces a plan-time diagnostic rather than an API error.
+func TestAccNetwork_InvalidCIDR(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitProviderConfig + `
+resource "seca_network" "invalid" {
+  name         = "test-network"
+  workspace_id = "fake-workspace"
+  sku_id       = "fake-sku"
+  cidr = {
+    ipv4 = "not-a-valid-cidr"
+  }
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Invalid (IPv4 )?CIDR`),
+			},
+		},
+	})
+}
+
+// TestAccSecurityGroup_InvalidDirection verifies that an unrecognised direction
+// value triggers a plan-time enum validation error.
+func TestAccSecurityGroup_InvalidDirection(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitProviderConfig + `
+resource "seca_security_group" "invalid" {
+  name         = "test-sg"
+  workspace_id = "fake-workspace"
+  rules = [
+    {
+      direction = "forward"
+      protocol  = "tcp"
+    }
+  ]
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Invalid enum value`),
+			},
+		},
+	})
+}
+
+// TestAccSecurityGroup_InvalidPortRange verifies that port 0 fails plan-time
+// validation with a clear port-range error.
+func TestAccSecurityGroup_InvalidPortRange(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitProviderConfig + `
+resource "seca_security_group" "invalid" {
+  name         = "test-sg"
+  workspace_id = "fake-workspace"
+  rules = [
+    {
+      direction = "ingress"
+      protocol  = "tcp"
+      ports = {
+        from = 0
+      }
+    }
+  ]
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Invalid port number`),
+			},
+		},
+	})
+}
+
+// TestAccPublicIp_InvalidVersion verifies that an unrecognised IP version
+// (e.g. "IPv5") fails plan-time validation.
+func TestAccPublicIp_InvalidVersion(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitProviderConfig + `
+resource "seca_public_ip" "invalid" {
+  name         = "test-pip"
+  workspace_id = "fake-workspace"
+  version      = "IPv5"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Invalid enum value`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Apply-time API error tests (resource.Test — requires TF_ACC=1)
+// ---------------------------------------------------------------------------
+
+// TestAccBlockStorage_InvalidSKU verifies that creating a block-storage volume
+// with a non-existent SKU fails with a clear API error at apply time.
+func TestAccBlockStorage_InvalidSKU(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "seca_workspace" "test" {
+  name = "neg-test-workspace"
+}
+
+resource "seca_block_storage" "invalid_sku" {
+  name         = "neg-test-storage"
+  workspace_id = seca_workspace.test.id
+  size_gb      = 10
+  sku_id       = "nonexistent-sku-000"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)(error creating block storage|invalid.*sku|not found)`),
+			},
+		},
+	})
+}
+
+// TestAccBlockStorage_MissingWorkspace verifies that referencing a workspace
+// that does not exist produces a clear error diagnostic at apply time.
+func TestAccBlockStorage_MissingWorkspace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "seca_block_storage" "missing_ws" {
+  name         = "neg-test-storage"
+  workspace_id = "00000000-0000-0000-0000-000000000000"
+  size_gb      = 10
+  sku_id       = "some-sku"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)(error creating block storage|workspace.*not found|not found)`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_public_ip.go
+++ b/internal/provider/resource_public_ip.go
@@ -13,6 +13,7 @@ import (
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -138,6 +139,7 @@ func (r *PublicIpResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{StringEnumValidator("IPv4", "IPv6")},
 			},
 			"address": tfschema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
## Summary

- Adds `StringEnumValidator("IPv4", "IPv6")` to `seca_public_ip.version` for plan-time validation (missed in the original GA-40 implementation)
- Introduces `internal/provider/provider_acc_test.go` with shared provider test helpers (`testAccProtoV6ProviderFactories`, `testAccPreCheck`, `testAccProviderConfig`, `testUnitProviderConfig`) for use within the `provider` package
- Adds `internal/provider/resource_negative_test.go` with two categories of negative tests:
  - **Plan-time** (`resource.UnitTest`, no `TF_ACC` required): invalid CIDR on `seca_network`, invalid direction/port on `seca_security_group`, invalid IP version on `seca_public_ip`
  - **Apply-time** (`resource.Test`, requires `TF_ACC=1`): non-existent SKU and missing workspace on `seca_block_storage`

## Test plan

- [ ] `go test ./internal/provider/... -run 'TestAccNetwork_InvalidCIDR|TestAccSecurityGroup_Invalid|TestAccPublicIp_InvalidVersion'` passes without `TF_ACC`
- [ ] `TF_ACC=1 go test ./internal/provider/... -run 'TestAccBlockStorage_Invalid|TestAccBlockStorage_Missing'` passes against a live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)