### PR TITLE
fix: make public_ip_ids and security_group_ids computed

### DIFF
--- a/internal/provider/resource_nic.go
+++ b/internal/provider/resource_nic.go
@@ -154,6 +154,7 @@ func (r *NicResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 			"public_ip_ids": tfschema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},
@@ -161,6 +162,7 @@ func (r *NicResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 			"security_group_ids": tfschema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
Fixes: 
seca_nic.nic: Still creating... [00m30s elapsed]                                                                                                                                  
  ╷                                                                                                                                                                                 
  │ Error: Provider produced inconsistent result after apply                                                                                                                        
  │                                                                                                                                                                                 
  │ When applying changes to seca_nic.nic, provider "provider[\"registry.terraform.io/eu-sovereign-cloud/seca\"]" produced an unexpected new value: .public_ip_ids: was             
  │ null, but now cty.ListValEmpty(cty.String).                                                                                                                                     
  │                                                                                                                                                                                 
  │ This is a bug in the provider, which should be reported in the provider's own issue tracker.                                                                                    
  ╵                                                                                                                                                                                 
  ╷                                                                                                                                                                                 
  │ Error: Provider produced inconsistent result after apply                                                                                                                        
  │                                                                                                                                                                                 
  │ When applying changes to seca_nic.nic, provider "provider[\"registry.terraform.io/eu-sovereign-cloud/seca\"]" produced an unexpected new value:                                 
  │ .security_group_ids: was null, but now cty.ListValEmpty(cty.String).                                                                                                            
  │                                                                                                                                                                                 
  │ This is a bug in the provider, which should be reported in the provider's own issue tracker.